### PR TITLE
PALU MLRD (Feature)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -201,6 +201,7 @@ message(STATUS "FetchContent base directory: ${FETCHCONTENT_BASE_DIR}")
 set(VLLM_EXT_SRC
   "csrc/cache_kernels.cu"
   "csrc/attention/attention_kernels.cu"
+  "csrc/attention/attention_kernels_palu.cu"
   "csrc/pos_encoding_kernels.cu"
   "csrc/activation_kernels.cu"
   "csrc/layernorm_kernels.cu"

--- a/csrc/attention/attention_kernels_palu.cu
+++ b/csrc/attention/attention_kernels_palu.cu
@@ -371,6 +371,7 @@ __device__ void paged_attention_mlrd_palu_kernel(
           k_vecs[j] = k_vecs_up[j];
       }
 
+      // TODO(kerem): Apply RoPE to k_vecs.
 
       // Compute dot product.
       // This includes a reduction across the threads in the same thread group.

--- a/csrc/attention/attention_kernels_palu.cu
+++ b/csrc/attention/attention_kernels_palu.cu
@@ -1,0 +1,1193 @@
+/*
+ * Adapted from
+ * https://github.com/NVIDIA/FasterTransformer/blob/release/v5.3_tag/src/fastertransformer/kernels/decoder_masked_multihead_attention/decoder_masked_multihead_attention_template.hpp
+ * Copyright (c) 2023, The vLLM team.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <torch/all.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <algorithm>
+
+#include "attention_dtypes.h"
+#include "attention_utils.cuh"
+
+#ifdef USE_ROCM
+  #include <hip/hip_bf16.h>
+  #include "../quantization/fp8/amd/quant_utils.cuh"
+typedef __hip_bfloat16 __nv_bfloat16;
+#else
+  #include "../quantization/fp8/nvidia/quant_utils.cuh"
+#endif
+
+#ifndef USE_ROCM
+  #define WARP_SIZE 32
+#else
+  #define WARP_SIZE warpSize
+#endif
+
+#define MAX(a, b) ((a) > (b) ? (a) : (b))
+#define MIN(a, b) ((a) < (b) ? (a) : (b))
+#define DIVIDE_ROUND_UP(a, b) (((a) + (b) - 1) / (b))
+
+namespace vllm {
+
+// Utility function for attention softmax.
+template <int NUM_WARPS>
+inline __device__ float block_sum(float* red_smem, float sum) {
+  // Decompose the thread index into warp / lane.
+  int warp = threadIdx.x / WARP_SIZE;
+  int lane = threadIdx.x % WARP_SIZE;
+
+  // Compute the sum per warp.
+#pragma unroll
+  for (int mask = WARP_SIZE / 2; mask >= 1; mask /= 2) {
+    sum += VLLM_SHFL_XOR_SYNC(sum, mask);
+  }
+
+  // Warp leaders store the data to shared memory.
+  if (lane == 0) {
+    red_smem[warp] = sum;
+  }
+
+  // Make sure the data is in shared memory.
+  __syncthreads();
+
+  // The warps compute the final sums.
+  if (lane < NUM_WARPS) {
+    sum = red_smem[lane];
+  }
+
+  // Parallel reduction inside the warp.
+#pragma unroll
+  for (int mask = NUM_WARPS / 2; mask >= 1; mask /= 2) {
+    sum += VLLM_SHFL_XOR_SYNC(sum, mask);
+  }
+
+  // Broadcast to other threads.
+  return VLLM_SHFL_SYNC(sum, 0);
+}
+
+// TODO(woosuk): Merge the last two dimensions of the grid.
+// Grid: (num_heads, num_seqs, max_num_partitions).
+// Implements M-LRD (Multi-Head Low Rank Decomposition).
+// THREAD_GROUP_SIZE is set to 1 so that we can up project k_vecs with matrix [PALU_HEAD_SIZE, HEAD_SIZE] per thread.
+template <typename scalar_t, // data type of query, key and value data elements
+          typename cache_t, // data type of key and value cache elements
+          int HEAD_SIZE, // number of elements in each original head (q)
+          int PALU_HEAD_SIZE, // number of elements in each compressed palu head (k,v)
+          int BLOCK_SIZE, // number of tokens in each block
+          int NUM_THREADS, // number of threads in the thread block
+          vllm::Fp8KVCacheDataType KV_DTYPE, // key and value cache data type
+          bool IS_BLOCK_SPARSE, // whether to use blocksparse attention
+          int PARTITION_SIZE = 0>  // Zero means no partitioning, tensor parallelism.
+__device__ void paged_attention_mlrd_palu_kernel(
+    float* __restrict__ exp_sums,  // [num_seqs, num_heads, max_num_partitions]
+    float* __restrict__ max_logits,  // [num_seqs, num_heads,
+                                     // max_num_partitions]
+    scalar_t* __restrict__ out,  // [num_seqs, num_heads, max_num_partitions,
+                                 // head_size]
+    const scalar_t* __restrict__ q,       // [num_seqs, num_heads, head_size]
+    const cache_t* __restrict__ k_cache,  // [num_blocks, num_kv_heads,
+                                          // head_size/x, block_size, x]
+    const scalar_t* __restrict__ palu_k_up_proj,  // [num_heads, palu_head_size, head_size]
+    const cache_t* __restrict__ v_cache,  // [num_blocks, num_kv_heads,
+                                          // head_size, block_size]
+    const int num_kv_heads,               // [num_heads]
+    const float scale,
+    const int* __restrict__ block_tables,  // [num_seqs, max_num_blocks_per_seq]
+    const int* __restrict__ seq_lens,      // [num_seqs]
+    const int max_num_blocks_per_seq,
+    const float* __restrict__ alibi_slopes,  // [num_heads]
+    const int q_stride, const int kv_block_stride, const int kv_head_stride,
+    const float k_scale, const float v_scale, const int tp_rank,
+    const int blocksparse_local_blocks, const int blocksparse_vert_stride,
+    const int blocksparse_block_size, const int blocksparse_head_sliding_step) {
+  const int seq_idx = blockIdx.y;
+  const int partition_idx = blockIdx.z;
+  const int max_num_partitions = gridDim.z;
+  constexpr bool USE_PARTITIONING = PARTITION_SIZE > 0;
+  const int seq_len = seq_lens[seq_idx];
+  if (USE_PARTITIONING && partition_idx * PARTITION_SIZE >= seq_len) {
+    // No work to do. Terminate the thread block.
+    return;
+  }
+  // Set WARP_SIZE to BLOCK_SIZE so that each thread will process all elements of a single head of a single key token.
+  // #define WARP_SIZE BLOCK_SIZE
+  // check that WARP_SIZE is equal to BLOCK_SIZE, otherwise raise an error
+  if (WARP_SIZE != BLOCK_SIZE) {
+    printf("Error: WARP_SIZE and BLOCK_SIZE should be equal to have a thread group size of 1 for MLRD Palu kernel.\n");
+    assert(WARP_SIZE == BLOCK_SIZE);
+  }
+
+  const int num_seq_blocks = DIVIDE_ROUND_UP(seq_len, BLOCK_SIZE);
+  const int num_blocks_per_partition =
+      USE_PARTITIONING ? PARTITION_SIZE / BLOCK_SIZE : num_seq_blocks;
+
+  // [start_block_idx, end_block_idx) is the range of blocks to process.
+  const int start_block_idx =
+      USE_PARTITIONING ? partition_idx * num_blocks_per_partition : 0;
+  const int end_block_idx =
+      MIN(start_block_idx + num_blocks_per_partition, num_seq_blocks);
+  const int num_blocks = end_block_idx - start_block_idx;
+
+  // [start_token_idx, end_token_idx) is the range of tokens to process.
+  const int start_token_idx = start_block_idx * BLOCK_SIZE;
+  const int end_token_idx =
+      MIN(start_token_idx + num_blocks * BLOCK_SIZE, seq_len);
+  const int num_tokens = end_token_idx - start_token_idx;
+
+  constexpr int THREAD_GROUP_SIZE = MAX(WARP_SIZE / BLOCK_SIZE, 1);
+  constexpr int NUM_THREAD_GROUPS =
+      NUM_THREADS / THREAD_GROUP_SIZE;  // Note: This assumes THREAD_GROUP_SIZE
+                                        // divides NUM_THREADS
+  assert(NUM_THREADS % THREAD_GROUP_SIZE == 0);
+  constexpr int NUM_TOKENS_PER_THREAD_GROUP =
+      DIVIDE_ROUND_UP(BLOCK_SIZE, WARP_SIZE);
+  constexpr int NUM_WARPS = NUM_THREADS / WARP_SIZE;
+  const int thread_idx = threadIdx.x;
+  const int warp_idx = thread_idx / WARP_SIZE;
+  const int lane = thread_idx % WARP_SIZE;
+
+  const int head_idx = blockIdx.x;
+  const int num_heads = gridDim.x;
+  const int num_queries_per_kv = num_heads / num_kv_heads;
+  const int kv_head_idx = head_idx / num_queries_per_kv;
+  const float alibi_slope =
+      alibi_slopes == nullptr ? 0.f : alibi_slopes[head_idx];
+
+  // A vector type to store a part of a key or a query.
+  // The vector size is configured in such a way that the threads in a thread
+  // group fetch or compute 16 bytes at a time. For example, if the size of a
+  // thread group is 4 and the data type is half, then the vector size is 16 /
+  // (4 * sizeof(half)) == 2.
+  constexpr int VEC_SIZE = MAX(16 / (THREAD_GROUP_SIZE * sizeof(scalar_t)), 1);
+  constexpr int PALU_VEC_SIZE = MAX(16 / (THREAD_GROUP_SIZE * sizeof(cache_t)), 1) / (HEAD_SIZE / PALU_HEAD_SIZE);
+  using K_vec = typename Vec<scalar_t, PALU_VEC_SIZE>::Type;
+  using Q_vec = typename Vec<scalar_t, VEC_SIZE>::Type;
+  using Quant_vec = typename Vec<cache_t, VEC_SIZE>::Type;
+
+  constexpr int NUM_ELEMS_PER_THREAD = HEAD_SIZE / THREAD_GROUP_SIZE;
+  constexpr int NUM_PALU_ELEMS_PER_THREAD = PALU_HEAD_SIZE / THREAD_GROUP_SIZE;
+  constexpr int NUM_VECS_PER_THREAD = NUM_ELEMS_PER_THREAD / VEC_SIZE;
+  constexpr int NUM_PALU_VECS_PER_THREAD = NUM_PALU_ELEMS_PER_THREAD / PALU_VEC_SIZE;
+
+  // NUM_VECS_PER_THREAD and NUM_PALU_VECS_PER_THREAD should be equal.
+  assert(NUM_VECS_PER_THREAD == NUM_PALU_VECS_PER_THREAD);
+
+  const int thread_group_idx = thread_idx / THREAD_GROUP_SIZE;
+  const int thread_group_offset = thread_idx % THREAD_GROUP_SIZE;
+
+  // Load the query to registers.
+  // Each thread in a thread group has a different part of the query.
+  // For example, if the the thread group size is 4, then the first thread in
+  // the group has 0, 4, 8, ... th vectors of the query, and the second thread
+  // has 1, 5, 9, ... th vectors of the query, and so on. NOTE(woosuk): Because
+  // q is split from a qkv tensor, it may not be contiguous.
+  const scalar_t* q_ptr = q + seq_idx * q_stride + head_idx * HEAD_SIZE;
+  __shared__ Q_vec q_vecs[THREAD_GROUP_SIZE][NUM_VECS_PER_THREAD];
+#pragma unroll
+  for (int i = thread_group_idx; i < NUM_VECS_PER_THREAD;
+       i += NUM_THREAD_GROUPS) {
+    const int vec_idx = thread_group_offset + i * THREAD_GROUP_SIZE;
+    q_vecs[thread_group_offset][i] =
+        *reinterpret_cast<const Q_vec*>(q_ptr + vec_idx * VEC_SIZE);
+  }
+  __syncthreads();  // TODO(naed90): possible speedup if this is replaced with a
+                    // memory wall right before we use q_vecs
+
+  // Memory planning.
+  extern __shared__ char shared_mem[];
+  // NOTE(woosuk): We use FP32 for the softmax logits for better accuracy.
+  float* logits = reinterpret_cast<float*>(shared_mem);
+  // Workspace for reduction.
+  __shared__ float red_smem[2 * NUM_WARPS];
+
+  // x == THREAD_GROUP_SIZE * VEC_SIZE
+  // Each thread group fetches x elements from the key at a time.
+  constexpr int x = 16 / sizeof(cache_t);
+  float qk_max = -FLT_MAX;
+
+  // Iterate over the key blocks.
+  // Each warp fetches a block of keys for each iteration.
+  // Each thread group in a warp fetches a key from the block, and computes
+  // dot product with the query.
+  const int* block_table = block_tables + seq_idx * max_num_blocks_per_seq;
+
+  // blocksparse specific vars
+  int bs_block_offset;
+  int q_bs_block_id;
+  if constexpr (IS_BLOCK_SPARSE) {
+    // const int num_blocksparse_blocks = DIVIDE_ROUND_UP(seq_len,
+    // blocksparse_block_size);
+    q_bs_block_id = (seq_len - 1) / blocksparse_block_size;
+    if (blocksparse_head_sliding_step >= 0)
+      // sliding on q heads
+      bs_block_offset =
+          (tp_rank * num_heads + head_idx) * blocksparse_head_sliding_step + 1;
+    else
+      // sliding on kv heads
+      bs_block_offset = (tp_rank * num_kv_heads + kv_head_idx) *
+                            (-blocksparse_head_sliding_step) +
+                        1;
+  }
+
+  for (int block_idx = start_block_idx + warp_idx; block_idx < end_block_idx;
+       block_idx += NUM_WARPS) {
+    // NOTE(woosuk): The block number is stored in int32. However, we cast it to
+    // int64 because int32 can lead to overflow when this variable is multiplied
+    // by large numbers (e.g., kv_block_stride).
+    // For blocksparse attention: skip computation on blocks that are not
+    // attended
+    if constexpr (IS_BLOCK_SPARSE) {
+      const int k_bs_block_id = block_idx * BLOCK_SIZE / blocksparse_block_size;
+      const bool is_remote =
+          ((k_bs_block_id + bs_block_offset) % blocksparse_vert_stride == 0);
+      const bool is_local =
+          (k_bs_block_id > q_bs_block_id - blocksparse_local_blocks);
+      if (!is_remote && !is_local) {
+        for (int i = 0; i < NUM_TOKENS_PER_THREAD_GROUP; i++) {
+          const int physical_block_offset =
+              (thread_group_idx + i * WARP_SIZE) % BLOCK_SIZE;
+          const int token_idx = block_idx * BLOCK_SIZE + physical_block_offset;
+
+          if (thread_group_offset == 0) {
+            // NOTE(linxihui): assign very large number to skipped tokens to
+            // avoid contribution to the sumexp softmax normalizer. This will
+            // not be used at computing sum(softmax*v) as the blocks will be
+            // skipped.
+            logits[token_idx - start_token_idx] = -FLT_MAX;
+          }
+        }
+        continue;
+      }
+    }
+    const int64_t physical_block_number =
+        static_cast<int64_t>(block_table[block_idx]);
+
+    // Load a key to registers.
+    // Each thread in a thread group has a different part of the key.
+    // For example, if the the thread group size is 4, then the first thread in
+    // the group has 0, 4, 8, ... th vectors of the key, and the second thread
+    // has 1, 5, 9, ... th vectors of the key, and so on.
+    for (int i = 0; i < NUM_TOKENS_PER_THREAD_GROUP; i++) {
+      const int physical_block_offset =
+          (thread_group_idx + i * WARP_SIZE) % BLOCK_SIZE;
+      const int token_idx = block_idx * BLOCK_SIZE + physical_block_offset;
+      K_vec k_vecs[NUM_PALU_VECS_PER_THREAD];
+
+#pragma unroll
+      for (int j = 0; j < NUM_PALU_VECS_PER_THREAD; j++) {
+        const cache_t* k_ptr =
+            k_cache + physical_block_number * kv_block_stride +
+            kv_head_idx * kv_head_stride + physical_block_offset * x;
+        const int vec_idx = thread_group_offset + j * THREAD_GROUP_SIZE;
+        const int offset1 = (vec_idx * PALU_VEC_SIZE) / x;
+        const int offset2 = (vec_idx * PALU_VEC_SIZE) % x;
+
+        if constexpr (KV_DTYPE == Fp8KVCacheDataType::kAuto) {
+          k_vecs[j] = *reinterpret_cast<const K_vec*>(
+              k_ptr + offset1 * BLOCK_SIZE * x + offset2);
+        } else {
+          // Vector conversion from Quant_vec to K_vec.
+          Quant_vec k_vec_quant = *reinterpret_cast<const Quant_vec*>(
+              k_ptr + offset1 * BLOCK_SIZE * x + offset2);
+          k_vecs[j] = fp8::scaled_convert<K_vec, Quant_vec, KV_DTYPE>(
+              k_vec_quant, k_scale);
+        }
+      }
+
+      // Before qk dot product, up project key elements using palu_k_up_proj matrix.
+      // Each element of k_vec will be up projected from PALU_VEC_SIZE to VEC_SIZE.
+      // k_vecs has NUM_PALU_VECS_PER_THREAD many vectors with PALU_VEC_SIZE elements each. 
+      // Also, let's say PALU_HEAD_SIZE=32 and HEAD_SIZE=128 this means compression rate is 4.
+      // palu_k_up_proj is [32, 128] matrix which will up project k_vecs.
+      // k_vecs has all the elements of a single token of a single key head.
+      Q_vec k_vecs_up[NUM_VECS_PER_THREAD];
+      
+      // Load palu_k_up_proj matrix into shared memory
+      // - palu_k_up_proj is a [num_heads, PALU_HEAD_SIZE, HEAD_SIZE] matrix in global memory
+      // - We load the slice for the current head (head_idx) into shared memory
+      // - Using all NUM_THREADS threads to load, regardless of their dimensional arrangement
+      // - Each thread may load multiple elements if PALU_HEAD_SIZE * HEAD_SIZE > NUM_THREADS
+      // - Strided loading ensures even distribution of work across threads
+      // - __syncthreads() at the end ensures all data is loaded before computation begins
+      __shared__ scalar_t shared_palu_k_up_proj[PALU_HEAD_SIZE][HEAD_SIZE];
+
+      const int num_elements = PALU_HEAD_SIZE * HEAD_SIZE;
+      for (int i = threadIdx.x; i < num_elements; i += NUM_THREADS) {
+          int row = i / HEAD_SIZE;
+          int col = i % HEAD_SIZE;
+          shared_palu_k_up_proj[row][col] = palu_k_up_proj[head_idx * num_elements + i];
+      }
+      __syncthreads();
+
+      // Up projection with matrix [PALU_HEAD_SIZE, HEAD_SIZE] per thread, k_vecs and k_vecs_up are per thread.
+      // NUM_VECS_PER_THREAD is equal to NUM_PALU_VECS_PER_THREAD.
+      // For examples, let's assume k_vecs = [64 elements][64 elements] and k_vecs_up = [128 elements][128 elements].
+      // PALU_HEAD_SIZE = 128 and HEAD_SIZE = 256.
+      // Up projection is responsible for dot product between all elements of k_vecs and a given column of palu_k_up_proj matrix.
+      // The index of resulting dot product is stored in k_vecs_up.
+      // for (int j = 0; j < HEAD_SIZE; j++) {
+      //     int k_vecs_up_idx = j / VEC_SIZE;
+      //     int k_vecs_up_elem_idx = j % VEC_SIZE;
+
+      //     scalar_t vec_up_elem = 0;
+      //     for (int i = 0; i < PALU_HEAD_SIZE; i++) {
+      //         int k_vecs_idx = i / PALU_VEC_SIZE;
+      //         int k_vecs_elem_idx = i % PALU_VEC_SIZE;        
+      //         vec_up_elem += reinterpret_cast<scalar_t*>(&k_vecs[k_vecs_idx])[k_vecs_elem_idx] * shared_palu_k_up_proj[i][j];
+      //     }
+      //     reinterpret_cast<scalar_t*>(&k_vecs_up[k_vecs_up_idx])[k_vecs_up_elem_idx] = vec_up_elem;
+      // }
+      for (int j = 0; j < HEAD_SIZE; j += VEC_SIZE) {
+          Q_vec result = {0};
+          for (int i = 0; i < PALU_HEAD_SIZE; i++) {
+              K_vec k_vec = k_vecs[i / PALU_VEC_SIZE];
+              scalar_t k_elem = reinterpret_cast<scalar_t*>(&k_vec)[i % PALU_VEC_SIZE];
+              
+              #pragma unroll
+              for (int l = 0; l < VEC_SIZE; l++) {
+                  reinterpret_cast<scalar_t*>(&result)[l] += k_elem * shared_palu_k_up_proj[i][j + l];
+              }
+          }
+          k_vecs_up[j / VEC_SIZE] = result;
+      }
+
+      for (int j = 0; j < NUM_VECS_PER_THREAD; j++) {
+          k_vecs[j] = k_vecs_up[j];
+      }
+
+
+      // Compute dot product.
+      // This includes a reduction across the threads in the same thread group.
+      float qk = scale * Qk_dot<scalar_t, THREAD_GROUP_SIZE>::dot(
+                             q_vecs[thread_group_offset], k_vecs);
+      // Add the ALiBi bias if slopes are given.
+      qk += (alibi_slope != 0) ? alibi_slope * (token_idx - seq_len + 1) : 0;
+
+      if (thread_group_offset == 0) {
+        // Store the partial reductions to shared memory.
+        // NOTE(woosuk): It is required to zero out the masked logits.
+        const bool mask = token_idx >= seq_len;
+        logits[token_idx - start_token_idx] = mask ? 0.f : qk;
+        // Update the max value.
+        qk_max = mask ? qk_max : fmaxf(qk_max, qk);
+      }
+    }
+  }
+
+  // Perform reduction across the threads in the same warp to get the
+  // max qk value for each "warp" (not across the thread block yet).
+  // The 0-th thread of each thread group already has its max qk value.
+#pragma unroll
+  for (int mask = WARP_SIZE / 2; mask >= THREAD_GROUP_SIZE; mask /= 2) {
+    qk_max = fmaxf(qk_max, VLLM_SHFL_XOR_SYNC(qk_max, mask));
+  }
+  if (lane == 0) {
+    red_smem[warp_idx] = qk_max;
+  }
+  __syncthreads();
+
+  // TODO(woosuk): Refactor this part.
+  // Get the max qk value for the sequence.
+  qk_max = lane < NUM_WARPS ? red_smem[lane] : -FLT_MAX;
+#pragma unroll
+  for (int mask = NUM_WARPS / 2; mask >= 1; mask /= 2) {
+    qk_max = fmaxf(qk_max, VLLM_SHFL_XOR_SYNC(qk_max, mask));
+  }
+  // Broadcast the max qk value to all threads.
+  qk_max = VLLM_SHFL_SYNC(qk_max, 0);
+
+  // Get the sum of the exp values.
+  float exp_sum = 0.f;
+  for (int i = thread_idx; i < num_tokens; i += NUM_THREADS) {
+    float val = __expf(logits[i] - qk_max);
+    logits[i] = val;
+    exp_sum += val;
+  }
+  exp_sum = block_sum<NUM_WARPS>(&red_smem[NUM_WARPS], exp_sum);
+
+  // Compute softmax.
+  const float inv_sum = __fdividef(1.f, exp_sum + 1e-6f);
+  for (int i = thread_idx; i < num_tokens; i += NUM_THREADS) {
+    logits[i] *= inv_sum;
+  }
+  __syncthreads();
+
+  // If partitioning is enabled, store the max logit and exp_sum.
+  if (USE_PARTITIONING && thread_idx == 0) {
+    float* max_logits_ptr = max_logits +
+                            seq_idx * num_heads * max_num_partitions +
+                            head_idx * max_num_partitions + partition_idx;
+    *max_logits_ptr = qk_max;
+    float* exp_sums_ptr = exp_sums + seq_idx * num_heads * max_num_partitions +
+                          head_idx * max_num_partitions + partition_idx;
+    *exp_sums_ptr = exp_sum;
+  }
+
+  // Each thread will fetch 16 bytes from the value cache at a time.
+  constexpr int V_VEC_SIZE = MIN(16 / sizeof(scalar_t), BLOCK_SIZE);
+  using V_vec = typename Vec<scalar_t, V_VEC_SIZE>::Type;
+  using L_vec = typename Vec<scalar_t, V_VEC_SIZE>::Type;
+  using V_quant_vec = typename Vec<cache_t, V_VEC_SIZE>::Type;
+  using Float_L_vec = typename FloatVec<L_vec>::Type;
+
+  constexpr int NUM_V_VECS_PER_ROW = BLOCK_SIZE / V_VEC_SIZE;
+  constexpr int NUM_ROWS_PER_ITER = WARP_SIZE / NUM_V_VECS_PER_ROW;
+  constexpr int NUM_ROWS_PER_THREAD =
+      DIVIDE_ROUND_UP(HEAD_SIZE, NUM_ROWS_PER_ITER);
+
+  // NOTE(woosuk): We use FP32 for the accumulator for better accuracy.
+  float accs[NUM_ROWS_PER_THREAD];
+#pragma unroll
+  for (int i = 0; i < NUM_ROWS_PER_THREAD; i++) {
+    accs[i] = 0.f;
+  }
+
+  scalar_t zero_value;
+  zero(zero_value);
+  for (int block_idx = start_block_idx + warp_idx; block_idx < end_block_idx;
+       block_idx += NUM_WARPS) {
+    // NOTE(woosuk): The block number is stored in int32. However, we cast it to
+    // int64 because int32 can lead to overflow when this variable is multiplied
+    // by large numbers (e.g., kv_block_stride).
+    // For blocksparse attention: skip computation on blocks that are not
+    // attended
+    if constexpr (IS_BLOCK_SPARSE) {
+      int v_bs_block_id = block_idx * BLOCK_SIZE / blocksparse_block_size;
+      if (!((v_bs_block_id + bs_block_offset) % blocksparse_vert_stride == 0) &&
+          !((v_bs_block_id > q_bs_block_id - blocksparse_local_blocks))) {
+        continue;
+      }
+    }
+    const int64_t physical_block_number =
+        static_cast<int64_t>(block_table[block_idx]);
+    const int physical_block_offset = (lane % NUM_V_VECS_PER_ROW) * V_VEC_SIZE;
+    const int token_idx = block_idx * BLOCK_SIZE + physical_block_offset;
+    L_vec logits_vec;
+    from_float(logits_vec, *reinterpret_cast<Float_L_vec*>(logits + token_idx -
+                                                           start_token_idx));
+
+    const cache_t* v_ptr = v_cache + physical_block_number * kv_block_stride +
+                           kv_head_idx * kv_head_stride;
+#pragma unroll
+    for (int i = 0; i < NUM_ROWS_PER_THREAD; i++) {
+      const int row_idx = lane / NUM_V_VECS_PER_ROW + i * NUM_ROWS_PER_ITER;
+      if (row_idx < HEAD_SIZE) {
+        const int offset = row_idx * BLOCK_SIZE + physical_block_offset;
+        V_vec v_vec;
+
+        if constexpr (KV_DTYPE == Fp8KVCacheDataType::kAuto) {
+          v_vec = *reinterpret_cast<const V_vec*>(v_ptr + offset);
+        } else {
+          V_quant_vec v_quant_vec =
+              *reinterpret_cast<const V_quant_vec*>(v_ptr + offset);
+          // Vector conversion from V_quant_vec to V_vec.
+          v_vec = fp8::scaled_convert<V_vec, V_quant_vec, KV_DTYPE>(v_quant_vec,
+                                                                    v_scale);
+        }
+        if (block_idx == num_seq_blocks - 1) {
+          // NOTE(woosuk): When v_vec contains the tokens that are out of the
+          // context, we should explicitly zero out the values since they may
+          // contain NaNs. See
+          // https://github.com/vllm-project/vllm/issues/641#issuecomment-1682544472
+          scalar_t* v_vec_ptr = reinterpret_cast<scalar_t*>(&v_vec);
+#pragma unroll
+          for (int j = 0; j < V_VEC_SIZE; j++) {
+            v_vec_ptr[j] = token_idx + j < seq_len ? v_vec_ptr[j] : zero_value;
+          }
+        }
+        accs[i] += dot(logits_vec, v_vec);
+      }
+    }
+  }
+
+  // Perform reduction within each warp.
+#pragma unroll
+  for (int i = 0; i < NUM_ROWS_PER_THREAD; i++) {
+    float acc = accs[i];
+#pragma unroll
+    for (int mask = NUM_V_VECS_PER_ROW / 2; mask >= 1; mask /= 2) {
+      acc += VLLM_SHFL_XOR_SYNC(acc, mask);
+    }
+    accs[i] = acc;
+  }
+
+  // NOTE(woosuk): A barrier is required because the shared memory space for
+  // logits is reused for the output.
+  __syncthreads();
+
+  // Perform reduction across warps.
+  float* out_smem = reinterpret_cast<float*>(shared_mem);
+#pragma unroll
+  for (int i = NUM_WARPS; i > 1; i /= 2) {
+    int mid = i / 2;
+    // Upper warps write to shared memory.
+    if (warp_idx >= mid && warp_idx < i) {
+      float* dst = &out_smem[(warp_idx - mid) * HEAD_SIZE];
+#pragma unroll
+      for (int i = 0; i < NUM_ROWS_PER_THREAD; i++) {
+        const int row_idx = lane / NUM_V_VECS_PER_ROW + i * NUM_ROWS_PER_ITER;
+        if (row_idx < HEAD_SIZE && lane % NUM_V_VECS_PER_ROW == 0) {
+          dst[row_idx] = accs[i];
+        }
+      }
+    }
+    __syncthreads();
+
+    // Lower warps update the output.
+    if (warp_idx < mid) {
+      const float* src = &out_smem[warp_idx * HEAD_SIZE];
+#pragma unroll
+      for (int i = 0; i < NUM_ROWS_PER_THREAD; i++) {
+        const int row_idx = lane / NUM_V_VECS_PER_ROW + i * NUM_ROWS_PER_ITER;
+        if (row_idx < HEAD_SIZE && lane % NUM_V_VECS_PER_ROW == 0) {
+          accs[i] += src[row_idx];
+        }
+      }
+    }
+    __syncthreads();
+  }
+
+  // Write the final output.
+  if (warp_idx == 0) {
+    scalar_t* out_ptr =
+        out + seq_idx * num_heads * max_num_partitions * HEAD_SIZE +
+        head_idx * max_num_partitions * HEAD_SIZE + partition_idx * HEAD_SIZE;
+#pragma unroll
+    for (int i = 0; i < NUM_ROWS_PER_THREAD; i++) {
+      const int row_idx = lane / NUM_V_VECS_PER_ROW + i * NUM_ROWS_PER_ITER;
+      if (row_idx < HEAD_SIZE && lane % NUM_V_VECS_PER_ROW == 0) {
+        from_float(*(out_ptr + row_idx), accs[i]);
+      }
+    }
+  }
+}
+
+// Grid: (num_heads, num_seqs, 1).
+template <typename scalar_t, typename cache_t, int HEAD_SIZE, int PALU_HEAD_SIZE, int BLOCK_SIZE,
+          int NUM_THREADS, vllm::Fp8KVCacheDataType KV_DTYPE,
+          bool IS_BLOCK_SPARSE>
+__global__ void paged_attention_mlrd_palu_v1_kernel(
+    scalar_t* __restrict__ out,           // [num_seqs, num_heads, head_size]
+    const scalar_t* __restrict__ q,       // [num_seqs, num_heads, head_size]
+    const cache_t* __restrict__ k_cache,  // [num_blocks, num_kv_heads,
+                                          // head_size/x, block_size, x]
+    const scalar_t* __restrict__ palu_k_up_proj,  // [num_heads, palu_head_size, head_size]
+    const cache_t* __restrict__ v_cache,  // [num_blocks, num_kv_heads,
+                                          // head_size, block_size]
+    const int num_kv_heads,               // [num_heads]
+    const float scale,
+    const int* __restrict__ block_tables,  // [num_seqs, max_num_blocks_per_seq]
+    const int* __restrict__ seq_lens,      // [num_seqs]
+    const int max_num_blocks_per_seq,
+    const float* __restrict__ alibi_slopes,  // [num_heads]
+    const int q_stride, const int kv_block_stride, const int kv_head_stride,
+    const float k_scale, const float v_scale, const int tp_rank,
+    const int blocksparse_local_blocks, const int blocksparse_vert_stride,
+    const int blocksparse_block_size, const int blocksparse_head_sliding_step) {
+  paged_attention_mlrd_palu_kernel<scalar_t, cache_t, HEAD_SIZE, PALU_HEAD_SIZE, BLOCK_SIZE, NUM_THREADS,
+                         KV_DTYPE, IS_BLOCK_SPARSE>(
+      /* exp_sums */ nullptr, /* max_logits */ nullptr, out, q, k_cache, palu_k_up_proj,
+      v_cache, num_kv_heads, scale, block_tables, seq_lens,
+      max_num_blocks_per_seq, alibi_slopes, q_stride, kv_block_stride,
+      kv_head_stride, k_scale, v_scale, tp_rank, blocksparse_local_blocks,
+      blocksparse_vert_stride, blocksparse_block_size,
+      blocksparse_head_sliding_step);
+}
+
+// Grid: (num_heads, num_seqs, max_num_partitions).
+template <typename scalar_t, typename cache_t, int HEAD_SIZE, int PALU_HEAD_SIZE, int BLOCK_SIZE,
+          int NUM_THREADS, vllm::Fp8KVCacheDataType KV_DTYPE,
+          bool IS_BLOCK_SPARSE,
+          int PARTITION_SIZE>
+__global__ void paged_attention_mlrd_palu_v2_kernel(
+    float* __restrict__ exp_sums,  // [num_seqs, num_heads, max_num_partitions]
+    float* __restrict__ max_logits,       // [num_seqs, num_heads,
+                                          // max_num_partitions]
+    scalar_t* __restrict__ tmp_out,       // [num_seqs, num_heads,
+                                          // max_num_partitions, head_size]
+    const scalar_t* __restrict__ q,       // [num_seqs, num_heads, head_size]
+    const cache_t* __restrict__ k_cache,  // [num_blocks, num_kv_heads,
+                                          // head_size/x, block_size, x]
+    const scalar_t* __restrict__ palu_k_up_proj,  // [num_heads, palu_head_size, head_size]
+    const cache_t* __restrict__ v_cache,  // [num_blocks, num_kv_heads,
+                                          // head_size, block_size]
+    const int num_kv_heads,               // [num_heads]
+    const float scale,
+    const int* __restrict__ block_tables,  // [num_seqs, max_num_blocks_per_seq]
+    const int* __restrict__ seq_lens,      // [num_seqs]
+    const int max_num_blocks_per_seq,
+    const float* __restrict__ alibi_slopes,  // [num_heads]
+    const int q_stride, const int kv_block_stride, const int kv_head_stride,
+    const float k_scale, const float v_scale, const int tp_rank,
+    const int blocksparse_local_blocks, const int blocksparse_vert_stride,
+    const int blocksparse_block_size, const int blocksparse_head_sliding_step) {
+  paged_attention_mlrd_palu_kernel<scalar_t, cache_t, HEAD_SIZE, PALU_HEAD_SIZE, BLOCK_SIZE, NUM_THREADS,
+                         KV_DTYPE, IS_BLOCK_SPARSE, PARTITION_SIZE>(
+      exp_sums, max_logits, tmp_out, q, k_cache, palu_k_up_proj, v_cache, num_kv_heads, scale,
+      block_tables, seq_lens, max_num_blocks_per_seq, alibi_slopes, q_stride,
+      kv_block_stride, kv_head_stride, k_scale, v_scale, tp_rank,
+      blocksparse_local_blocks, blocksparse_vert_stride, blocksparse_block_size,
+      blocksparse_head_sliding_step);
+}
+
+// Grid: (num_heads, num_seqs).
+template <typename scalar_t, int HEAD_SIZE, int NUM_THREADS,
+          int PARTITION_SIZE>
+__global__ void paged_attention_v2_reduce_kernel(
+    scalar_t* __restrict__ out,            // [num_seqs, num_heads, head_size]
+    const float* __restrict__ exp_sums,    // [num_seqs, num_heads,
+                                           // max_num_partitions]
+    const float* __restrict__ max_logits,  // [num_seqs, num_heads,
+                                           // max_num_partitions]
+    const scalar_t* __restrict__ tmp_out,  // [num_seqs, num_heads,
+                                           // max_num_partitions, head_size]
+    const int* __restrict__ seq_lens,      // [num_seqs]
+    const int max_num_partitions) {
+  const int num_heads = gridDim.x;
+  const int head_idx = blockIdx.x;
+  const int seq_idx = blockIdx.y;
+  const int seq_len = seq_lens[seq_idx];
+  const int num_partitions = DIVIDE_ROUND_UP(seq_len, PARTITION_SIZE);
+  if (num_partitions == 1) {
+    // No need to reduce. Only copy tmp_out to out.
+    scalar_t* out_ptr =
+        out + seq_idx * num_heads * HEAD_SIZE + head_idx * HEAD_SIZE;
+    const scalar_t* tmp_out_ptr =
+        tmp_out + seq_idx * num_heads * max_num_partitions * HEAD_SIZE +
+        head_idx * max_num_partitions * HEAD_SIZE;
+    for (int i = threadIdx.x; i < HEAD_SIZE; i += blockDim.x) {
+      out_ptr[i] = tmp_out_ptr[i];
+    }
+    // Terminate the thread block.
+    return;
+  }
+
+  constexpr int NUM_WARPS = NUM_THREADS / WARP_SIZE;
+  const int warp_idx = threadIdx.x / WARP_SIZE;
+  const int lane = threadIdx.x % WARP_SIZE;
+
+  // Size: 2 * num_partitions.
+  extern __shared__ char shared_mem[];
+  // Workspace for reduction.
+  __shared__ float red_smem[2 * NUM_WARPS];
+
+  // Load max logits to shared memory.
+  float* shared_max_logits = reinterpret_cast<float*>(shared_mem);
+  const float* max_logits_ptr = max_logits +
+                                seq_idx * num_heads * max_num_partitions +
+                                head_idx * max_num_partitions;
+  float max_logit = -FLT_MAX;
+  for (int i = threadIdx.x; i < num_partitions; i += blockDim.x) {
+    const float l = max_logits_ptr[i];
+    shared_max_logits[i] = l;
+    max_logit = fmaxf(max_logit, l);
+  }
+  __syncthreads();
+
+  // Get the global max logit.
+  // Reduce within the warp.
+#pragma unroll
+  for (int mask = WARP_SIZE / 2; mask >= 1; mask /= 2) {
+    max_logit = fmaxf(max_logit, VLLM_SHFL_XOR_SYNC(max_logit, mask));
+  }
+  if (lane == 0) {
+    red_smem[warp_idx] = max_logit;
+  }
+  __syncthreads();
+  // Reduce across warps.
+  max_logit = lane < NUM_WARPS ? red_smem[lane] : -FLT_MAX;
+#pragma unroll
+  for (int mask = NUM_WARPS / 2; mask >= 1; mask /= 2) {
+    max_logit = fmaxf(max_logit, VLLM_SHFL_XOR_SYNC(max_logit, mask));
+  }
+  // Broadcast the max value to all threads.
+  max_logit = VLLM_SHFL_SYNC(max_logit, 0);
+
+  // Load rescaled exp sums to shared memory.
+  float* shared_exp_sums =
+      reinterpret_cast<float*>(shared_mem + sizeof(float) * num_partitions);
+  const float* exp_sums_ptr = exp_sums +
+                              seq_idx * num_heads * max_num_partitions +
+                              head_idx * max_num_partitions;
+  float global_exp_sum = 0.0f;
+  for (int i = threadIdx.x; i < num_partitions; i += blockDim.x) {
+    float l = shared_max_logits[i];
+    float rescaled_exp_sum = exp_sums_ptr[i] * expf(l - max_logit);
+    global_exp_sum += rescaled_exp_sum;
+    shared_exp_sums[i] = rescaled_exp_sum;
+  }
+  __syncthreads();
+  global_exp_sum = block_sum<NUM_WARPS>(&red_smem[NUM_WARPS], global_exp_sum);
+  const float inv_global_exp_sum = __fdividef(1.0f, global_exp_sum + 1e-6f);
+
+  // Aggregate tmp_out to out.
+  const scalar_t* tmp_out_ptr =
+      tmp_out + seq_idx * num_heads * max_num_partitions * HEAD_SIZE +
+      head_idx * max_num_partitions * HEAD_SIZE;
+  scalar_t* out_ptr =
+      out + seq_idx * num_heads * HEAD_SIZE + head_idx * HEAD_SIZE;
+#pragma unroll
+  for (int i = threadIdx.x; i < HEAD_SIZE; i += NUM_THREADS) {
+    float acc = 0.0f;
+    for (int j = 0; j < num_partitions; ++j) {
+      acc += to_float(tmp_out_ptr[j * HEAD_SIZE + i]) * shared_exp_sums[j] *
+             inv_global_exp_sum;
+    }
+    from_float(out_ptr[i], acc);
+  }
+}
+
+}  // namespace vllm
+
+#define LAUNCH_PAGED_ATTENTION_MLRD_PALU_V1(HEAD_SIZE, PALU_HEAD_SIZE)                                \
+  VLLM_DevFuncAttribute_SET_MaxDynamicSharedMemorySize(                     \
+      ((void*)vllm::paged_attention_mlrd_palu_v1_kernel<T, CACHE_T, HEAD_SIZE, PALU_HEAD_SIZE,        \
+                                              BLOCK_SIZE, NUM_THREADS,      \
+                                              KV_DTYPE, IS_BLOCK_SPARSE>),  \
+      shared_mem_size);                                                     \
+  vllm::paged_attention_mlrd_palu_v1_kernel<T, CACHE_T, HEAD_SIZE, PALU_HEAD_SIZE, BLOCK_SIZE,        \
+                                  NUM_THREADS, KV_DTYPE, IS_BLOCK_SPARSE>   \
+      <<<grid, block, shared_mem_size, stream>>>(                           \
+          out_ptr, query_ptr, key_cache_ptr, palu_k_up_proj_ptr, value_cache_ptr, num_kv_heads, \
+          scale, block_tables_ptr, seq_lens_ptr, max_num_blocks_per_seq,    \
+          alibi_slopes_ptr, q_stride, kv_block_stride, kv_head_stride,      \
+          k_scale, v_scale, tp_rank, blocksparse_local_blocks,              \
+          blocksparse_vert_stride, blocksparse_block_size,                  \
+          blocksparse_head_sliding_step);
+
+// TODO(woosuk): Tune NUM_THREADS.
+template <typename T, typename CACHE_T, int BLOCK_SIZE,
+          vllm::Fp8KVCacheDataType KV_DTYPE, bool IS_BLOCK_SPARSE,
+          int NUM_THREADS = 128>
+void paged_attention_mlrd_palu_v1_launcher(
+    torch::Tensor& out, torch::Tensor& query, torch::Tensor& key_cache, 
+    torch::Tensor& palu_k_up_proj, torch::Tensor& value_cache, int num_kv_heads, float scale,
+    torch::Tensor& block_tables, torch::Tensor& seq_lens, int max_seq_len,
+    const c10::optional<torch::Tensor>& alibi_slopes, float k_scale,
+    float v_scale, const int tp_rank, const int blocksparse_local_blocks,
+    const int blocksparse_vert_stride, const int blocksparse_block_size,
+    const int blocksparse_head_sliding_step) {
+  int num_seqs = query.size(0);
+  int num_heads = query.size(1);
+  int head_size = query.size(2);
+  int palu_head_size = palu_k_up_proj.size(1);
+  int max_num_blocks_per_seq = block_tables.size(1);
+  int q_stride = query.stride(0);
+  int kv_block_stride = key_cache.stride(0);
+  int kv_head_stride = key_cache.stride(1);
+
+  // set WARP_SIZE equal to BLOCK_SIZE so that thread group size is 1.
+  WARP_SIZE = BLOCK_SIZE;
+  [[maybe_unused]] int thread_group_size = MAX(WARP_SIZE / BLOCK_SIZE, 1);
+  assert(head_size % thread_group_size == 0);
+
+  // NOTE: alibi_slopes is optional.
+  const float* alibi_slopes_ptr =
+      alibi_slopes
+          ? reinterpret_cast<const float*>(alibi_slopes.value().data_ptr())
+          : nullptr;
+
+  T* out_ptr = reinterpret_cast<T*>(out.data_ptr());
+  T* query_ptr = reinterpret_cast<T*>(query.data_ptr());
+  CACHE_T* key_cache_ptr = reinterpret_cast<CACHE_T*>(key_cache.data_ptr());
+  T* palu_k_up_proj_ptr = reinterpret_cast<T*>(palu_k_up_proj.data_ptr());
+  CACHE_T* value_cache_ptr = reinterpret_cast<CACHE_T*>(value_cache.data_ptr());
+  int* block_tables_ptr = block_tables.data_ptr<int>();
+  int* seq_lens_ptr = seq_lens.data_ptr<int>();
+
+  constexpr int NUM_WARPS = NUM_THREADS / WARP_SIZE;
+  int padded_max_seq_len =
+      DIVIDE_ROUND_UP(max_seq_len, BLOCK_SIZE) * BLOCK_SIZE;
+  int logits_size = padded_max_seq_len * sizeof(float);
+  int outputs_size = (NUM_WARPS / 2) * head_size * sizeof(float);
+  // Python-side check in vllm.worker.worker._check_if_can_support_max_seq_len
+  // Keep that in sync with the logic here!
+  int shared_mem_size = std::max(logits_size, outputs_size);
+
+  dim3 grid(num_heads, num_seqs, 1);
+  dim3 block(NUM_THREADS);
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(query));
+  const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+  switch (head_size) {
+    // NOTE(woosuk): To reduce the compilation time, we only compile for the
+    // head sizes that we use in the model and their corresponding PALU head sizes.
+    // We compile for PALU_HEAD_SIZE being 1/4 or 1/8 of HEAD_SIZE.
+    case 64:
+      if (palu_head_size == 16) {
+        LAUNCH_PAGED_ATTENTION_MLRD_PALU_V1(64, 16);
+      } else if (palu_head_size == 8) {
+        LAUNCH_PAGED_ATTENTION_MLRD_PALU_V1(64, 8);
+      } else {
+        TORCH_CHECK(false, "Unsupported PALU head size for head size 64: ", palu_head_size);
+      }
+      break;
+    case 80:
+      if (palu_head_size == 20) {
+        LAUNCH_PAGED_ATTENTION_MLRD_PALU_V1(80, 20);
+      } else if (palu_head_size == 10) {
+        LAUNCH_PAGED_ATTENTION_MLRD_PALU_V1(80, 10);
+      } else {
+        TORCH_CHECK(false, "Unsupported PALU head size for head size 80: ", palu_head_size);
+      }
+      break;
+    case 96:
+      if (palu_head_size == 24) {
+        LAUNCH_PAGED_ATTENTION_MLRD_PALU_V1(96, 24);
+      } else if (palu_head_size == 12) {
+        LAUNCH_PAGED_ATTENTION_MLRD_PALU_V1(96, 12);
+      } else {
+        TORCH_CHECK(false, "Unsupported PALU head size for head size 96: ", palu_head_size);
+      }
+      break;
+    case 112:
+      if (palu_head_size == 28) {
+        LAUNCH_PAGED_ATTENTION_MLRD_PALU_V1(112, 28);
+      } else if (palu_head_size == 14) {
+        LAUNCH_PAGED_ATTENTION_MLRD_PALU_V1(112, 14);
+      } else {
+        TORCH_CHECK(false, "Unsupported PALU head size for head size 112: ", palu_head_size);
+      }
+      break;
+    case 120:
+      if (palu_head_size == 30) {
+        LAUNCH_PAGED_ATTENTION_MLRD_PALU_V1(120, 30);
+      } else if (palu_head_size == 15) {
+        LAUNCH_PAGED_ATTENTION_MLRD_PALU_V1(120, 15);
+      } else {
+        TORCH_CHECK(false, "Unsupported PALU head size for head size 120: ", palu_head_size);
+      }
+      break;
+    case 128:
+      if (palu_head_size == 32) {
+        LAUNCH_PAGED_ATTENTION_MLRD_PALU_V1(128, 32);
+      } else if (palu_head_size == 16) {
+        LAUNCH_PAGED_ATTENTION_MLRD_PALU_V1(128, 16);
+      } else {
+        TORCH_CHECK(false, "Unsupported PALU head size for head size 128: ", palu_head_size);
+      }
+      break;
+    case 192:
+      if (palu_head_size == 48) {
+        LAUNCH_PAGED_ATTENTION_MLRD_PALU_V1(192, 48);
+      } else if (palu_head_size == 24) {
+        LAUNCH_PAGED_ATTENTION_MLRD_PALU_V1(192, 24);
+      } else {
+        TORCH_CHECK(false, "Unsupported PALU head size for head size 192: ", palu_head_size);
+      }
+      break;
+    case 256:
+      if (palu_head_size == 64) {
+        LAUNCH_PAGED_ATTENTION_MLRD_PALU_V1(256, 64);
+      } else if (palu_head_size == 32) {
+        LAUNCH_PAGED_ATTENTION_MLRD_PALU_V1(256, 32);
+      } else {
+        TORCH_CHECK(false, "Unsupported PALU head size for head size 256: ", palu_head_size);
+      }
+      break;
+    default:
+      TORCH_CHECK(false, "Unsupported head size: ", head_size);
+      break;
+  }
+}
+
+#define CALL_MLRD_PALU_V1_LAUNCHER(T, CACHE_T, BLOCK_SIZE, KV_DTYPE, IS_BLOCK_SPARSE)  \
+  paged_attention_mlrd_palu_v1_launcher<T, CACHE_T, BLOCK_SIZE, KV_DTYPE,              \
+                              IS_BLOCK_SPARSE>(                              \
+      out, query, key_cache, palu_k_up_proj, value_cache, num_kv_heads, scale, block_tables, \
+      seq_lens, max_seq_len, alibi_slopes, k_scale, v_scale, tp_rank,        \
+      blocksparse_local_blocks, blocksparse_vert_stride,                     \
+      blocksparse_block_size, blocksparse_head_sliding_step);
+
+#define CALL_MLRD_PALU_V1_LAUNCHER_SPARSITY(T, CACHE_T, BLOCK_SIZE, IS_FP8_KV_CACHE) \
+  switch (is_block_sparse) {                                               \
+    case true:                                                             \
+      CALL_MLRD_PALU_V1_LAUNCHER(T, CACHE_T, BLOCK_SIZE, IS_FP8_KV_CACHE, true);     \
+      break;                                                               \
+    case false:                                                            \
+      CALL_MLRD_PALU_V1_LAUNCHER(T, CACHE_T, BLOCK_SIZE, IS_FP8_KV_CACHE, false);    \
+      break;                                                               \
+  }
+
+// NOTE(woosuk): To reduce the compilation time, we omitted block sizes
+// 1, 2, 4, 64, 128, 256.
+#define CALL_MLRD_PALU_V1_LAUNCHER_BLOCK_SIZE(T, CACHE_T, KV_DTYPE)         \
+  switch (block_size) {                                           \
+    case 8:                                                       \
+      CALL_MLRD_PALU_V1_LAUNCHER_SPARSITY(T, CACHE_T, 8, KV_DTYPE);         \
+      break;                                                      \
+    case 16:                                                      \
+      CALL_MLRD_PALU_V1_LAUNCHER_SPARSITY(T, CACHE_T, 16, KV_DTYPE);        \
+      break;                                                      \
+    case 32:                                                      \
+      CALL_MLRD_PALU_V1_LAUNCHER_SPARSITY(T, CACHE_T, 32, KV_DTYPE);        \
+      break;                                                      \
+    default:                                                      \
+      TORCH_CHECK(false, "Unsupported block size: ", block_size); \
+      break;                                                      \
+  }
+
+void paged_attention_mlrd_palu_v1(
+    torch::Tensor& out,    // [num_seqs, num_heads, head_size]
+    torch::Tensor& query,  // [num_seqs, num_heads, head_size]
+    torch::Tensor&
+        key_cache,  // [num_blocks, num_heads, head_size/x, block_size, x]
+    torch::Tensor& palu_k_up_proj, // [num_heads, palu_head_size, block_size]
+    torch::Tensor&
+        value_cache,       // [num_blocks, num_heads, head_size, block_size]
+    int64_t num_kv_heads,  // [num_heads]
+    double scale,
+    torch::Tensor& block_tables,  // [num_seqs, max_num_blocks_per_seq]
+    torch::Tensor& seq_lens,      // [num_seqs]
+    int64_t block_size, int64_t max_seq_len,
+    const c10::optional<torch::Tensor>& alibi_slopes,
+    const std::string& kv_cache_dtype, double k_scale, double v_scale,
+    const int64_t tp_rank, const int64_t blocksparse_local_blocks,
+    const int64_t blocksparse_vert_stride, const int64_t blocksparse_block_size,
+    const int64_t blocksparse_head_sliding_step) {
+  const bool is_block_sparse = (blocksparse_vert_stride > 1);
+
+  DISPATCH_BY_KV_CACHE_DTYPE(query.dtype(), kv_cache_dtype,
+                             CALL_V1_LAUNCHER_BLOCK_SIZE)
+}
+
+#define LAUNCH_PAGED_ATTENTION_MLRD_PALU_V2(HEAD_SIZE, PALU_HEAD_SIZE)                                   \
+  vllm::paged_attention_mlrd_palu_v2_kernel<T, CACHE_T, HEAD_SIZE, PALU_HEAD_SIZE, BLOCK_SIZE,           \
+                                  NUM_THREADS, KV_DTYPE, IS_BLOCK_SPARSE,      \
+                                  PARTITION_SIZE>                              \
+      <<<grid, block, shared_mem_size, stream>>>(                              \
+          exp_sums_ptr, max_logits_ptr, tmp_out_ptr, query_ptr, key_cache_ptr, palu_k_up_proj_ptr, \
+          value_cache_ptr, num_kv_heads, scale, block_tables_ptr,              \
+          seq_lens_ptr, max_num_blocks_per_seq, alibi_slopes_ptr, q_stride,    \
+          kv_block_stride, kv_head_stride, k_scale, v_scale, tp_rank,          \
+          blocksparse_local_blocks, blocksparse_vert_stride,                   \
+          blocksparse_block_size, blocksparse_head_sliding_step);              \
+  vllm::paged_attention_v2_reduce_kernel<T, HEAD_SIZE, NUM_THREADS,            \
+                                         PARTITION_SIZE>                       \
+      <<<reduce_grid, block, reduce_shared_mem_size, stream>>>(                \
+          out_ptr, exp_sums_ptr, max_logits_ptr, tmp_out_ptr, seq_lens_ptr,    \
+          max_num_partitions);
+
+template <typename T, typename CACHE_T, int BLOCK_SIZE,
+          vllm::Fp8KVCacheDataType KV_DTYPE, bool IS_BLOCK_SPARSE,
+          int NUM_THREADS = 128, int PARTITION_SIZE = 512>
+void paged_attention_mlrd_palu_v2_launcher(
+    torch::Tensor& out, torch::Tensor& exp_sums, torch::Tensor& max_logits,
+    torch::Tensor& tmp_out, torch::Tensor& query, torch::Tensor& key_cache, torch::Tensor& palu_k_up_proj,
+    torch::Tensor& value_cache, int num_kv_heads, float scale,
+    torch::Tensor& block_tables, torch::Tensor& seq_lens, int max_seq_len,
+    const c10::optional<torch::Tensor>& alibi_slopes, float k_scale,
+    float v_scale, const int tp_rank, const int blocksparse_local_blocks,
+    const int blocksparse_vert_stride, const int blocksparse_block_size,
+    const int blocksparse_head_sliding_step) {
+  int num_seqs = query.size(0);
+  int num_heads = query.size(1);
+  int head_size = query.size(2);
+  int palu_head_size = palu_k_up_proj.size(1);
+  int max_num_blocks_per_seq = block_tables.size(1);
+  int q_stride = query.stride(0);
+  int kv_block_stride = key_cache.stride(0);
+  int kv_head_stride = key_cache.stride(1);
+
+  // set WARP_SIZE equal to BLOCK_SIZE so that thread group size is 1.
+  WARP_SIZE = BLOCK_SIZE;
+  [[maybe_unused]] int thread_group_size = MAX(WARP_SIZE / BLOCK_SIZE, 1);
+  assert(head_size % thread_group_size == 0);
+
+  // NOTE: alibi_slopes is optional.
+  const float* alibi_slopes_ptr =
+      alibi_slopes
+          ? reinterpret_cast<const float*>(alibi_slopes.value().data_ptr())
+          : nullptr;
+
+  T* out_ptr = reinterpret_cast<T*>(out.data_ptr());
+  float* exp_sums_ptr = reinterpret_cast<float*>(exp_sums.data_ptr());
+  float* max_logits_ptr = reinterpret_cast<float*>(max_logits.data_ptr());
+  T* tmp_out_ptr = reinterpret_cast<T*>(tmp_out.data_ptr());
+  T* query_ptr = reinterpret_cast<T*>(query.data_ptr());
+  CACHE_T* key_cache_ptr = reinterpret_cast<CACHE_T*>(key_cache.data_ptr());
+  T* palu_k_up_proj_ptr = reinterpret_cast<T*>(palu_k_up_proj.data_ptr());
+  CACHE_T* value_cache_ptr = reinterpret_cast<CACHE_T*>(value_cache.data_ptr());
+  int* block_tables_ptr = block_tables.data_ptr<int>();
+  int* seq_lens_ptr = seq_lens.data_ptr<int>();
+
+  constexpr int NUM_WARPS = NUM_THREADS / WARP_SIZE;
+  int max_num_partitions = DIVIDE_ROUND_UP(max_seq_len, PARTITION_SIZE);
+  int logits_size = PARTITION_SIZE * sizeof(float);
+  int outputs_size = (NUM_WARPS / 2) * head_size * sizeof(float);
+
+  // For paged attention v2 kernel.
+  dim3 grid(num_heads, num_seqs, max_num_partitions);
+  int shared_mem_size = std::max(logits_size, outputs_size);
+  // For paged attention v2 reduce kernel.
+  dim3 reduce_grid(num_heads, num_seqs);
+  int reduce_shared_mem_size = 2 * max_num_partitions * sizeof(float);
+
+  dim3 block(NUM_THREADS);
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(query));
+  const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+  switch (head_size) {
+    // NOTE(woosuk): To reduce the compilation time, we only compile for the
+    // head sizes that we use in the model and their corresponding PALU head sizes.
+    // We compile for PALU_HEAD_SIZE being 1/4 or 1/8 of HEAD_SIZE.
+    case 64:
+      if (palu_head_size == 16) {
+        LAUNCH_PAGED_ATTENTION_MLRD_PALU_V2(64, 16);
+      } else if (palu_head_size == 8) {
+        LAUNCH_PAGED_ATTENTION_MLRD_PALU_V2(64, 8);
+      } else {
+        TORCH_CHECK(false, "Unsupported PALU head size for head size 64: ", palu_head_size);
+      }
+      break;
+    case 80:
+      if (palu_head_size == 20) {
+        LAUNCH_PAGED_ATTENTION_MLRD_PALU_V2(80, 20);
+      } else if (palu_head_size == 10) {
+        LAUNCH_PAGED_ATTENTION_MLRD_PALU_V2(80, 10);
+      } else {
+        TORCH_CHECK(false, "Unsupported PALU head size for head size 80: ", palu_head_size);
+      }
+      break;
+    case 96:
+      if (palu_head_size == 24) {
+        LAUNCH_PAGED_ATTENTION_MLRD_PALU_V2(96, 24);
+      } else if (palu_head_size == 12) {
+        LAUNCH_PAGED_ATTENTION_MLRD_PALU_V2(96, 12);
+      } else {
+        TORCH_CHECK(false, "Unsupported PALU head size for head size 96: ", palu_head_size);
+      }
+      break;
+    case 112:
+      if (palu_head_size == 28) {
+        LAUNCH_PAGED_ATTENTION_MLRD_PALU_V2(112, 28);
+      } else if (palu_head_size == 14) {
+        LAUNCH_PAGED_ATTENTION_MLRD_PALU_V2(112, 14);
+      } else {
+        TORCH_CHECK(false, "Unsupported PALU head size for head size 112: ", palu_head_size);
+      }
+      break;
+    case 120:
+      if (palu_head_size == 30) {
+        LAUNCH_PAGED_ATTENTION_MLRD_PALU_V2(120, 30);
+      } else if (palu_head_size == 15) {
+        LAUNCH_PAGED_ATTENTION_MLRD_PALU_V2(120, 15);
+      } else {
+        TORCH_CHECK(false, "Unsupported PALU head size for head size 120: ", palu_head_size);
+      }
+      break;
+    case 128:
+      if (palu_head_size == 32) {
+        LAUNCH_PAGED_ATTENTION_MLRD_PALU_V2(128, 32);
+      } else if (palu_head_size == 16) {
+        LAUNCH_PAGED_ATTENTION_MLRD_PALU_V2(128, 16);
+      } else {
+        TORCH_CHECK(false, "Unsupported PALU head size for head size 128: ", palu_head_size);
+      }
+      break;
+    case 192:
+      if (palu_head_size == 48) {
+        LAUNCH_PAGED_ATTENTION_MLRD_PALU_V2(192, 48);
+      } else if (palu_head_size == 24) {
+        LAUNCH_PAGED_ATTENTION_MLRD_PALU_V2(192, 24);
+      } else {
+        TORCH_CHECK(false, "Unsupported PALU head size for head size 192: ", palu_head_size);
+      }
+      break;
+    case 256:
+      if (palu_head_size == 64) {
+        LAUNCH_PAGED_ATTENTION_MLRD_PALU_V2(256, 64);
+      } else if (palu_head_size == 32) {
+        LAUNCH_PAGED_ATTENTION_MLRD_PALU_V2(256, 32);
+      } else {
+        TORCH_CHECK(false, "Unsupported PALU head size for head size 256: ", palu_head_size);
+      }
+      break;
+    default:
+      TORCH_CHECK(false, "Unsupported head size: ", head_size);
+      break;
+  }
+}
+
+#define CALL_MLRD_PALU_V2_LAUNCHER(T, CACHE_T, BLOCK_SIZE, KV_DTYPE, IS_BLOCK_SPARSE)   \
+  paged_attention_mlrd_palu_v2_launcher<T, CACHE_T, BLOCK_SIZE, KV_DTYPE,               \
+                              IS_BLOCK_SPARSE>(                               \
+      out, exp_sums, max_logits, tmp_out, query, key_cache, palu_k_up_proj, value_cache,      \
+      num_kv_heads, scale, block_tables, seq_lens, max_seq_len, alibi_slopes, \
+      k_scale, v_scale, tp_rank, blocksparse_local_blocks,                    \
+      blocksparse_vert_stride, blocksparse_block_size,                        \
+      blocksparse_head_sliding_step);
+
+#define CALL_MLRD_PALU_V2_LAUNCHER_SPARSITY(T, CACHE_T, BLOCK_SIZE, IS_FP8_KV_CACHE) \
+  switch (is_block_sparse) {                                               \
+    case true:                                                             \
+      CALL_MLRD_PALU_V2_LAUNCHER(T, CACHE_T, BLOCK_SIZE, IS_FP8_KV_CACHE, true);     \
+      break;                                                               \
+    case false:                                                            \
+      CALL_MLRD_PALU_V2_LAUNCHER(T, CACHE_T, BLOCK_SIZE, IS_FP8_KV_CACHE, false);    \
+      break;                                                               \
+  }
+
+// NOTE(woosuk): To reduce the compilation time, we omitted block sizes
+// 1, 2, 4, 64, 128, 256.
+#define CALL_MLRD_PALU_V2_LAUNCHER_BLOCK_SIZE(T, CACHE_T, KV_DTYPE)         \
+  switch (block_size) {                                           \
+    case 8:                                                       \
+      CALL_MLRD_PALU_V2_LAUNCHER_SPARSITY(T, CACHE_T, 8, KV_DTYPE);         \
+      break;                                                      \
+    case 16:                                                      \
+      CALL_MLRD_PALU_V2_LAUNCHER_SPARSITY(T, CACHE_T, 16, KV_DTYPE);        \
+      break;                                                      \
+    case 32:                                                      \
+      CALL_MLRD_PALU_V2_LAUNCHER_SPARSITY(T, CACHE_T, 32, KV_DTYPE);        \
+      break;                                                      \
+    default:                                                      \
+      TORCH_CHECK(false, "Unsupported block size: ", block_size); \
+      break;                                                      \
+  }
+
+void paged_attention_mlrd_palu_v2(
+    torch::Tensor& out,         // [num_seqs, num_heads, head_size]
+    torch::Tensor& exp_sums,    // [num_seqs, num_heads, max_num_partitions]
+    torch::Tensor& max_logits,  // [num_seqs, num_heads, max_num_partitions]
+    torch::Tensor&
+        tmp_out,  // [num_seqs, num_heads, max_num_partitions, head_size]
+    torch::Tensor& query,  // [num_seqs, num_heads, head_size]
+    torch::Tensor&
+        key_cache,  // [num_blocks, num_heads, head_size/x, block_size, x]
+    torch::Tensor& palu_k_up_proj, // [num_heads, palu_head_size, block_size]
+    torch::Tensor&
+        value_cache,       // [num_blocks, num_heads, head_size, block_size]
+    int64_t num_kv_heads,  // [num_heads]
+    double scale,
+    torch::Tensor& block_tables,  // [num_seqs, max_num_blocks_per_seq]
+    torch::Tensor& seq_lens,      // [num_seqs]
+    int64_t block_size, int64_t max_seq_len,
+    const c10::optional<torch::Tensor>& alibi_slopes,
+    const std::string& kv_cache_dtype, double k_scale, double v_scale,
+    const int64_t tp_rank, const int64_t blocksparse_local_blocks,
+    const int64_t blocksparse_vert_stride, const int64_t blocksparse_block_size,
+    const int64_t blocksparse_head_sliding_step) {
+  const bool is_block_sparse = (blocksparse_vert_stride > 1);
+  DISPATCH_BY_KV_CACHE_DTYPE(query.dtype(), kv_cache_dtype,
+                             CALL_V2_LAUNCHER_BLOCK_SIZE)
+}
+
+#undef WARP_SIZE
+#undef MAX
+#undef MIN
+#undef DIVIDE_ROUND_UP

--- a/csrc/ops.h
+++ b/csrc/ops.h
@@ -26,6 +26,27 @@ void paged_attention_v2(
     const int64_t blocksparse_vert_stride, const int64_t blocksparse_block_size,
     const int64_t blocksparse_head_sliding_step);
 
+void paged_attention_mlrd_palu_v1(
+    torch::Tensor& out, torch::Tensor& query, torch::Tensor& key_cache,
+    torch::Tensor& palu_k_up_proj, torch::Tensor& value_cache, int64_t num_kv_heads, double scale,
+    torch::Tensor& block_tables, torch::Tensor& seq_lens, int64_t block_size,
+    int64_t max_seq_len, const c10::optional<torch::Tensor>& alibi_slopes,
+    const std::string& kv_cache_dtype, double k_scale, double v_scale,
+    const int64_t tp_rank, const int64_t blocksparse_local_blocks,
+    const int64_t blocksparse_vert_stride, const int64_t blocksparse_block_size,
+    const int64_t blocksparse_head_sliding_step);
+
+void paged_attention_mlrd_palu_v2(
+    torch::Tensor& out, torch::Tensor& exp_sums, torch::Tensor& max_logits,
+    torch::Tensor& tmp_out, torch::Tensor& query, torch::Tensor& key_cache, torch::Tensor& palu_k_up_proj,
+    torch::Tensor& value_cache, int64_t num_kv_heads, double scale,
+    torch::Tensor& block_tables, torch::Tensor& seq_lens, int64_t block_size,
+    int64_t max_seq_len, const c10::optional<torch::Tensor>& alibi_slopes,
+    const std::string& kv_cache_dtype, double k_scale, double v_scale,
+    const int64_t tp_rank, const int64_t blocksparse_local_blocks,
+    const int64_t blocksparse_vert_stride, const int64_t blocksparse_block_size,
+    const int64_t blocksparse_head_sliding_step);
+
 void rms_norm(torch::Tensor& out, torch::Tensor& input, torch::Tensor& weight,
               double epsilon);
 

--- a/csrc/torch_bindings.cpp
+++ b/csrc/torch_bindings.cpp
@@ -47,6 +47,33 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
       "    int blocksparse_head_sliding_step) -> ()");
   ops.impl("paged_attention_v2", torch::kCUDA, &paged_attention_v2);
 
+  // PagedAttention MLRD PALU V1
+  ops.def(
+      "paged_attention_mlrd_palu_v1("
+      "    Tensor! out, Tensor query, Tensor key_cache,"
+      "    Tensor palu_k_up_proj, Tensor value_cache, int num_kv_heads, float scale,"
+      "    Tensor block_tables, Tensor seq_lens, int block_size,"
+      "    int max_seq_len, Tensor? alibi_slopes,"
+      "    str kv_cache_dtype, float k_scale, float v_scale,"
+      "    int tp_rank, int blocksparse_local_blocks,"
+      "    int blocksparse_vert_stride, int blocksparse_block_size,"
+      "    int blocksparse_head_sliding_step) -> ()");
+  ops.impl("paged_attention_mlrd_palu_v1", torch::kCUDA, &paged_attention_mlrd_palu_v1);
+  
+  // PagedAttention MLRD PALU V2
+  ops.def(
+      "paged_attention_mlrd_palu_v2("
+      "    Tensor! out, Tensor exp_sums, Tensor max_logits,"
+      "    Tensor tmp_out, Tensor query, Tensor key_cache, Tensor palu_k_up_proj,"
+      "    Tensor value_cache, int num_kv_heads, float scale,"
+      "    Tensor block_tables, Tensor seq_lens, int block_size,"
+      "    int max_seq_len, Tensor? alibi_slopes,"
+      "    str kv_cache_dtype, float k_scale, float v_scale,"
+      "    int tp_rank, int blocksparse_local_blocks,"
+      "    int blocksparse_vert_stride, int blocksparse_block_size,"
+      "    int blocksparse_head_sliding_step) -> ()");
+  ops.impl("paged_attention_mlrd_palu_v2", torch::kCUDA, &paged_attention_mlrd_palu_v2);
+
   // Activation ops
   // Activation function used in SwiGLU.
   ops.def("silu_and_mul(Tensor! out, Tensor input) -> ()");

--- a/tests/answerdotai/test_palu.ipynb
+++ b/tests/answerdotai/test_palu.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "id": "02c91ee7",
    "metadata": {},
    "outputs": [],
@@ -13,30 +13,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
-   "id": "afee8aca",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "torch.ops._C.paged_attention_mlrd_palu_v1??"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 12,
-   "id": "11fb1726",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "torch.ops._C.paged_attention_v1??"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "id": "31238c7a",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/k/miniconda3/envs/vllm_dev/lib/python3.10/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
+      "  from .autonotebook import tqdm as notebook_tqdm\n",
+      "2024-10-17 16:15:34,303\tINFO util.py:154 -- Missing packages: ['ipywidgets']. Run `pip install -U ipywidgets`, then restart the notebook server for rich notebook output.\n"
+     ]
+    }
+   ],
    "source": [
     "from vllm import _custom_ops as ops\n",
     "from vllm.utils import get_max_shared_memory_bytes, is_hip, seed_everything, create_kv_caches_with_random"
@@ -44,11 +34,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "id": "f2898590",
-   "metadata": {
-    "scrolled": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "FLOAT32_BYTES = torch.finfo(torch.float).bits // 8\n",
@@ -82,7 +70,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 59,
+   "execution_count": null,
    "id": "15e5f899",
    "metadata": {},
    "outputs": [],
@@ -96,7 +84,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 60,
+   "execution_count": null,
    "id": "13482506",
    "metadata": {},
    "outputs": [],
@@ -146,7 +134,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 61,
+   "execution_count": null,
    "id": "a5d7a077",
    "metadata": {},
    "outputs": [
@@ -156,7 +144,7 @@
        "(torch.Size([4321, 8, 16, 32, 8]), torch.Size([4321, 8, 128, 32]))"
       ]
      },
-     "execution_count": 61,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -167,41 +155,88 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 62,
+   "execution_count": null,
    "id": "0444d0b9",
-   "metadata": {
-    "scrolled": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# [num_kv_heads, palu_head_size, head_size]\n",
-    "palu_k_up_proj = torch.randn(5, 16, 128).to(dtype=dtype, device=device)"
+    "palu_k_up_proj = torch.ones(num_kv_heads, head_size//8, head_size).to(dtype=dtype, device=device)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 63,
-   "id": "b4a3643a",
+   "execution_count": null,
+   "id": "ca5f41e8",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "torch.Size([5, 16, 128])"
+       "tensor([[[1., 1., 1.,  ..., 1., 1., 1.],\n",
+       "         [1., 1., 1.,  ..., 1., 1., 1.],\n",
+       "         [1., 1., 1.,  ..., 1., 1., 1.],\n",
+       "         ...,\n",
+       "         [1., 1., 1.,  ..., 1., 1., 1.],\n",
+       "         [1., 1., 1.,  ..., 1., 1., 1.],\n",
+       "         [1., 1., 1.,  ..., 1., 1., 1.]],\n",
+       "\n",
+       "        [[1., 1., 1.,  ..., 1., 1., 1.],\n",
+       "         [1., 1., 1.,  ..., 1., 1., 1.],\n",
+       "         [1., 1., 1.,  ..., 1., 1., 1.],\n",
+       "         ...,\n",
+       "         [1., 1., 1.,  ..., 1., 1., 1.],\n",
+       "         [1., 1., 1.,  ..., 1., 1., 1.],\n",
+       "         [1., 1., 1.,  ..., 1., 1., 1.]],\n",
+       "\n",
+       "        [[1., 1., 1.,  ..., 1., 1., 1.],\n",
+       "         [1., 1., 1.,  ..., 1., 1., 1.],\n",
+       "         [1., 1., 1.,  ..., 1., 1., 1.],\n",
+       "         ...,\n",
+       "         [1., 1., 1.,  ..., 1., 1., 1.],\n",
+       "         [1., 1., 1.,  ..., 1., 1., 1.],\n",
+       "         [1., 1., 1.,  ..., 1., 1., 1.]],\n",
+       "\n",
+       "        ...,\n",
+       "\n",
+       "        [[1., 1., 1.,  ..., 1., 1., 1.],\n",
+       "         [1., 1., 1.,  ..., 1., 1., 1.],\n",
+       "         [1., 1., 1.,  ..., 1., 1., 1.],\n",
+       "         ...,\n",
+       "         [1., 1., 1.,  ..., 1., 1., 1.],\n",
+       "         [1., 1., 1.,  ..., 1., 1., 1.],\n",
+       "         [1., 1., 1.,  ..., 1., 1., 1.]],\n",
+       "\n",
+       "        [[1., 1., 1.,  ..., 1., 1., 1.],\n",
+       "         [1., 1., 1.,  ..., 1., 1., 1.],\n",
+       "         [1., 1., 1.,  ..., 1., 1., 1.],\n",
+       "         ...,\n",
+       "         [1., 1., 1.,  ..., 1., 1., 1.],\n",
+       "         [1., 1., 1.,  ..., 1., 1., 1.],\n",
+       "         [1., 1., 1.,  ..., 1., 1., 1.]],\n",
+       "\n",
+       "        [[1., 1., 1.,  ..., 1., 1., 1.],\n",
+       "         [1., 1., 1.,  ..., 1., 1., 1.],\n",
+       "         [1., 1., 1.,  ..., 1., 1., 1.],\n",
+       "         ...,\n",
+       "         [1., 1., 1.,  ..., 1., 1., 1.],\n",
+       "         [1., 1., 1.,  ..., 1., 1., 1.],\n",
+       "         [1., 1., 1.,  ..., 1., 1., 1.]]], device='cuda:0',\n",
+       "       dtype=torch.float16)"
       ]
      },
-     "execution_count": 63,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "palu_k_up_proj.shape"
+    "palu_k_up_proj"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 66,
+   "execution_count": null,
    "id": "bf386204",
    "metadata": {},
    "outputs": [],
@@ -211,21 +246,97 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 78,
-   "id": "6b92b629",
+   "execution_count": null,
+   "id": "7dd8b6af",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "output = torch.empty_like(query)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c22c3bb4",
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "The slowest run took 4.40 times longer than the fastest. This could mean that an intermediate result is being cached.\n",
-      "75.9 μs ± 59.9 μs per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
-     ]
+     "data": {
+      "text/plain": [
+       "tensor([[[ 1.5318e-05,  1.5318e-05,  1.5318e-05,  ...,  1.5318e-05,\n",
+       "           1.5318e-05,  1.5318e-05],\n",
+       "         [ 1.5318e-05,  1.5318e-05,  1.5318e-05,  ...,  1.5318e-05,\n",
+       "           1.5318e-05,  1.5318e-05],\n",
+       "         [ 1.5318e-05,  1.5318e-05,  1.5318e-05,  ...,  1.5318e-05,\n",
+       "           1.5318e-05,  1.5318e-05],\n",
+       "         ...,\n",
+       "         [ 1.5318e-05,  1.5318e-05,  1.5318e-05,  ...,  1.5318e-05,\n",
+       "           1.5318e-05,  1.5318e-05],\n",
+       "         [ 1.5318e-05,  1.5318e-05,  1.5318e-05,  ...,  1.5318e-05,\n",
+       "           1.5318e-05,  1.5318e-05],\n",
+       "         [ 1.5318e-05,  1.5318e-05,  1.5318e-05,  ...,  1.5318e-05,\n",
+       "           1.5318e-05,  1.5318e-05]],\n",
+       "\n",
+       "        [[ 1.5318e-05,  1.5318e-05,  1.5318e-05,  ...,  1.5318e-05,\n",
+       "           1.5318e-05,  1.5318e-05],\n",
+       "         [ 1.5318e-05,  1.5318e-05,  1.5318e-05,  ...,  1.5318e-05,\n",
+       "           1.5318e-05,  1.5318e-05],\n",
+       "         [ 1.5318e-05,  1.5318e-05,  1.5318e-05,  ...,  1.5318e-05,\n",
+       "           1.5318e-05,  1.5318e-05],\n",
+       "         ...,\n",
+       "         [ 1.5318e-05,  1.5318e-05,  1.5318e-05,  ...,  1.5318e-05,\n",
+       "           1.5318e-05,  1.5318e-05],\n",
+       "         [ 1.5318e-05,  1.5318e-05,  1.5318e-05,  ...,  1.5318e-05,\n",
+       "           1.5318e-05,  1.5318e-05],\n",
+       "         [ 1.5318e-05,  1.5318e-05,  1.5318e-05,  ...,  1.5318e-05,\n",
+       "           1.5318e-05,  1.5318e-05]],\n",
+       "\n",
+       "        [[ 2.0000e+00, -1.3994e+00,  7.8125e-03,  ...,  1.2607e+00,\n",
+       "          -0.0000e+00, -1.0752e+00],\n",
+       "         [ 2.0000e+00,  1.1787e+00,  2.0000e+00,  ...,  1.2607e+00,\n",
+       "          -2.0000e+00,  1.3643e+00],\n",
+       "         [-5.1200e+02,  8.3838e-01,  0.0000e+00,  ...,  1.3936e+00,\n",
+       "           2.0000e+00,  1.3086e+00],\n",
+       "         ...,\n",
+       "         [-5.1200e+02,  1.1523e+00,  7.8125e-03,  ..., -1.3926e+00,\n",
+       "           5.1200e+02,  1.2539e+00],\n",
+       "         [ 2.0000e+00, -1.1885e+00,  5.1200e+02,  ..., -9.4141e-01,\n",
+       "          -5.1200e+02,  1.4014e+00],\n",
+       "         [-7.8125e-03, -1.1650e+00, -7.8125e-03,  ...,  1.3857e+00,\n",
+       "          -7.8125e-03, -1.4033e+00]],\n",
+       "\n",
+       "        [[ 5.1200e+02, -1.1143e+00,  5.1200e+02,  ..., -1.2432e+00,\n",
+       "           0.0000e+00,  1.3857e+00],\n",
+       "         [-0.0000e+00,  1.3203e+00,  7.8125e-03,  ...,  1.2158e+00,\n",
+       "          -2.0000e+00, -1.4111e+00],\n",
+       "         [ 7.8125e-03, -1.3076e+00,  7.8125e-03,  ...,  1.2539e+00,\n",
+       "           2.0000e+00,  1.3779e+00],\n",
+       "         ...,\n",
+       "         [ 2.0000e+00,  1.3320e+00,  0.0000e+00,  ...,  1.0322e+00,\n",
+       "           5.1200e+02,  1.3105e+00],\n",
+       "         [ 0.0000e+00,  1.4160e+00, -0.0000e+00,  ..., -1.0869e+00,\n",
+       "          -7.8125e-03, -1.1895e+00],\n",
+       "         [ 5.1200e+02,  1.1475e+00, -0.0000e+00,  ...,  1.3965e+00,\n",
+       "          -7.8125e-03,  1.2988e+00]]], device='cuda:0', dtype=torch.float16)"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
-    "%%timeit -n 10\n",
+    "output"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6b92b629",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %%timeit -n 10\n",
     "output = torch.empty_like(query)\n",
     "ops.paged_attention_mlrd_palu_v1(\n",
     "    output,\n",
@@ -248,11 +359,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 80,
-   "id": "3c723186",
-   "metadata": {
-    "scrolled": true
-   },
+   "execution_count": null,
+   "id": "a26f6d4c",
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -291,7 +400,7 @@
        "       dtype=torch.float16)"
       ]
      },
-     "execution_count": 80,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -302,21 +411,76 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 79,
-   "id": "24084535",
+   "execution_count": null,
+   "id": "6307870f",
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "The slowest run took 4.25 times longer than the fastest. This could mean that an intermediate result is being cached.\n",
-      "74.1 μs ± 56.5 μs per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
+     "ename": "AssertionError",
+     "evalue": "",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mAssertionError\u001b[0m                            Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[51], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m \u001b[38;5;28;01massert\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m torch\u001b[38;5;241m.\u001b[39mall(output \u001b[38;5;241m==\u001b[39m \u001b[38;5;241m0\u001b[39m)\n",
+      "\u001b[0;31mAssertionError\u001b[0m: "
      ]
     }
    ],
    "source": [
-    "%%timeit -n 10\n",
+    "assert not torch.all(output == 0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "561bb383",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "torch.Size([4, 16, 128])"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "output.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3c723186",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "torch.Size([4, 16, 128])"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "output.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "24084535",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %%timeit -n 10\n",
     "output = torch.empty_like(query)\n",
     "ops.paged_attention_v1(\n",
     "    output,\n",
@@ -338,73 +502,48 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 73,
+   "execution_count": null,
    "id": "f1d10b1d",
-   "metadata": {
-    "scrolled": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "tensor([[[-2.2141e-02,  3.2616e-03, -2.3148e-02,  ..., -3.5370e-02,\n",
-       "          -1.2772e-02, -7.0190e-03],\n",
-       "         [-2.2217e-02,  3.1929e-03, -2.3148e-02,  ..., -3.5461e-02,\n",
-       "          -1.2871e-02, -6.9122e-03],\n",
-       "         [ 3.7415e-02, -3.6392e-03, -4.5898e-02,  ...,  6.8665e-05,\n",
-       "           4.7943e-02, -1.3275e-02],\n",
+       "tensor([[[ 0.0054, -0.0048, -0.0015,  ...,  0.0238, -0.0044, -0.0098],\n",
+       "         [ 0.0054, -0.0048, -0.0015,  ...,  0.0238, -0.0044, -0.0098],\n",
+       "         [-0.0051,  0.0019, -0.0152,  ...,  0.0002, -0.0081,  0.0030],\n",
        "         ...,\n",
-       "         [ 1.8997e-02, -1.2413e-02, -3.1982e-02,  ..., -5.6793e-02,\n",
-       "           4.4800e-02,  2.9755e-02],\n",
-       "         [ 1.3069e-02, -1.8433e-02,  4.1168e-02,  ...,  1.9741e-04,\n",
-       "           6.8817e-03,  2.7420e-02],\n",
-       "         [ 1.3123e-02, -1.8463e-02,  4.1351e-02,  ...,  1.0681e-04,\n",
-       "           6.9847e-03,  2.7435e-02]],\n",
+       "         [ 0.0134,  0.0103,  0.0134,  ..., -0.0143, -0.0222,  0.0170],\n",
+       "         [-0.0102, -0.0091,  0.0178,  ..., -0.0154,  0.0082, -0.0058],\n",
+       "         [-0.0103, -0.0092,  0.0179,  ..., -0.0153,  0.0083, -0.0057]],\n",
        "\n",
-       "        [[-8.0688e-02,  1.5297e-02,  6.9214e-02,  ..., -5.4474e-02,\n",
-       "          -5.7587e-02,  4.4769e-02],\n",
-       "         [-8.0688e-02,  1.5297e-02,  6.9214e-02,  ..., -5.4474e-02,\n",
-       "          -5.7587e-02,  4.4769e-02],\n",
-       "         [ 7.6172e-02,  8.5876e-02, -8.7891e-02,  ...,  2.2278e-02,\n",
-       "          -4.7755e-04,  7.1350e-02],\n",
+       "        [[ 0.0057,  0.0132,  0.0216,  ...,  0.0173,  0.0064,  0.0083],\n",
+       "         [ 0.0057,  0.0133,  0.0216,  ...,  0.0172,  0.0063,  0.0082],\n",
+       "         [ 0.0148, -0.0280, -0.0303,  ...,  0.0019, -0.0021, -0.0257],\n",
        "         ...,\n",
-       "         [ 3.8574e-02,  1.4069e-02,  4.4312e-02,  ..., -7.8003e-02,\n",
-       "           7.9529e-02, -3.9551e-02],\n",
-       "         [-8.5526e-03,  5.0049e-02,  3.8239e-02,  ...,  6.9519e-02,\n",
-       "           6.1462e-02,  4.4006e-02],\n",
-       "         [-8.5526e-03,  5.0049e-02,  3.8239e-02,  ...,  6.9519e-02,\n",
-       "           6.1462e-02,  4.4006e-02]],\n",
+       "         [ 0.0041, -0.0591, -0.0425,  ...,  0.0129,  0.0220, -0.0307],\n",
+       "         [ 0.0197,  0.0287, -0.0024,  ...,  0.0050,  0.0005, -0.0061],\n",
+       "         [ 0.0196,  0.0286, -0.0025,  ...,  0.0048,  0.0006, -0.0061]],\n",
        "\n",
-       "        [[ 1.9531e-02,  1.5625e-02,  3.0518e-05,  ...,  3.4576e-02,\n",
-       "          -2.9221e-03, -2.1000e-03],\n",
-       "         [ 1.9547e-02,  1.5579e-02, -7.6294e-06,  ...,  3.4607e-02,\n",
-       "          -2.9373e-03, -2.0943e-03],\n",
-       "         [-5.4550e-04, -2.2247e-02, -4.1161e-03,  ...,  9.7322e-04,\n",
-       "           2.6512e-03, -5.0774e-03],\n",
+       "        [[ 0.0138,  0.0034,  0.0209,  ..., -0.0127, -0.0015,  0.0013],\n",
+       "         [ 0.0137,  0.0034,  0.0209,  ..., -0.0127, -0.0015,  0.0013],\n",
+       "         [-0.0280, -0.0205,  0.0157,  ..., -0.0170, -0.0163,  0.0200],\n",
        "         ...,\n",
-       "         [ 2.2339e-02, -5.9624e-03, -9.9716e-03,  ..., -4.1779e-02,\n",
-       "          -1.7136e-02,  1.0071e-02],\n",
-       "         [-1.4259e-02,  2.1454e-02, -8.4305e-03,  ...,  7.5531e-04,\n",
-       "          -4.1870e-02, -1.7761e-02],\n",
-       "         [-1.4275e-02,  2.1454e-02, -8.5068e-03,  ...,  8.1825e-04,\n",
-       "          -4.1779e-02, -1.7822e-02]],\n",
+       "         [-0.0093, -0.0181, -0.0514,  ..., -0.0078,  0.0022, -0.0076],\n",
+       "         [-0.0187,  0.0048,  0.0153,  ..., -0.0241,  0.0068, -0.0044],\n",
+       "         [-0.0187,  0.0047,  0.0152,  ..., -0.0241,  0.0067, -0.0044]],\n",
        "\n",
-       "        [[-6.3705e-03, -7.1487e-03, -1.1375e-02,  ..., -2.1225e-02,\n",
-       "          -9.3460e-03,  5.1270e-03],\n",
-       "         [-6.3972e-03, -7.1793e-03, -1.1421e-02,  ..., -2.1225e-02,\n",
-       "          -9.3155e-03,  5.1346e-03],\n",
-       "         [-8.3923e-03,  1.7670e-02, -3.3913e-03,  ...,  8.9874e-03,\n",
-       "          -8.3847e-03, -8.0948e-03],\n",
+       "        [[-0.0027,  0.0073,  0.0038,  ..., -0.0007,  0.0042, -0.0083],\n",
+       "         [-0.0026,  0.0073,  0.0037,  ..., -0.0008,  0.0042, -0.0083],\n",
+       "         [ 0.0130, -0.0034,  0.0013,  ..., -0.0130,  0.0276, -0.0110],\n",
        "         ...,\n",
-       "         [ 1.4900e-02, -1.2207e-02, -8.0948e-03,  ..., -3.3493e-03,\n",
-       "           1.4633e-02, -4.0550e-03],\n",
-       "         [-3.8586e-03, -3.2234e-03, -5.1117e-03,  ...,  1.3397e-02,\n",
-       "           1.6220e-02,  7.9956e-03],\n",
-       "         [-3.8548e-03, -3.2425e-03, -5.1537e-03,  ...,  1.3344e-02,\n",
-       "           1.6327e-02,  8.0338e-03]]], device='cuda:0', dtype=torch.float16)"
+       "         [ 0.0042, -0.0361,  0.0122,  ..., -0.0104,  0.0105, -0.0144],\n",
+       "         [ 0.0029, -0.0025,  0.0083,  ...,  0.0155, -0.0046, -0.0202],\n",
+       "         [ 0.0029, -0.0025,  0.0083,  ...,  0.0155, -0.0047, -0.0202]]],\n",
+       "       device='cuda:0', dtype=torch.float16)"
       ]
      },
-     "execution_count": 73,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -440,21 +579,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "python3",
    "language": "python",
    "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.10.15"
   }
  },
  "nbformat": 4,

--- a/tests/answerdotai/test_palu.ipynb
+++ b/tests/answerdotai/test_palu.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "02c91ee7",
    "metadata": {},
    "outputs": [],
@@ -13,7 +13,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "31238c7a",
    "metadata": {},
    "outputs": [
@@ -35,25 +35,20 @@
   {
    "cell_type": "markdown",
    "id": "d1fcbd8d",
-   "metadata": {
-    "heading_collapsed": true
-   },
+   "metadata": {},
    "source": [
     "### test random\n",
     "\n",
     "Test palu kernel random inputs.\n",
     "\n",
-    "- Output should have some random values.\n",
-    "- **FIXME:** Write now output is all zeros, meaning that it is not updated or there is an error in kernel?"
+    "- Output should have some random values."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "f2898590",
-   "metadata": {
-    "hidden": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "FLOAT32_BYTES = torch.finfo(torch.float).bits // 8\n",
@@ -87,11 +82,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "15e5f899",
-   "metadata": {
-    "hidden": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "num_heads = (16, 8)\n",
@@ -103,11 +96,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "80300fa8",
-   "metadata": {
-    "hidden": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "palu_head_size = head_size // 8"
@@ -115,11 +106,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "13482506",
-   "metadata": {
-    "hidden": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# seed_everything(seed)\n",
@@ -167,11 +156,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "a5d7a077",
-   "metadata": {
-    "hidden": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -179,7 +166,7 @@
        "(torch.Size([4321, 8, 2, 32, 8]), torch.Size([4321, 8, 16, 32]))"
       ]
      },
-     "execution_count": 7,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -190,11 +177,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "0444d0b9",
-   "metadata": {
-    "hidden": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# [num_kv_heads, palu_head_size, head_size]\n",
@@ -203,12 +188,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "id": "ca5f41e8",
-   "metadata": {
-    "hidden": true,
-    "scrolled": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "assert palu_k_up_proj.is_contiguous()"
@@ -216,11 +198,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "id": "bf386204",
-   "metadata": {
-    "hidden": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "alibi_slopes = None"
@@ -228,12 +208,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "id": "70546996",
-   "metadata": {
-    "hidden": true,
-    "scrolled": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -295,7 +272,7 @@
        "          1.0000e+00, 1.0000e+00]]], device='cuda:0')"
       ]
      },
-     "execution_count": 16,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -306,11 +283,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "id": "8487b091",
-   "metadata": {
-    "hidden": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# %%timeit -n 10\n",
@@ -335,12 +310,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "id": "4055fcc8",
-   "metadata": {
-    "hidden": true,
-    "scrolled": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -402,7 +374,7 @@
        "          1.0000e+00, 1.0000e+00]]], device='cuda:0')"
       ]
      },
-     "execution_count": 18,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -413,11 +385,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "id": "5db20a61",
-   "metadata": {
-    "hidden": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -425,7 +395,7 @@
        "torch.Size([4, 16, 16])"
       ]
      },
-     "execution_count": 19,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -436,11 +406,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "id": "7b93bc0b",
-   "metadata": {
-    "hidden": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -453,7 +421,7 @@
        " torch.Size([4, 16, 128]))"
       ]
      },
-     "execution_count": 20,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -472,7 +440,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 63,
+   "execution_count": null,
    "id": "d91f13aa",
    "metadata": {},
    "outputs": [],
@@ -495,7 +463,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 64,
+   "execution_count": null,
    "id": "6ffdcfd7",
    "metadata": {},
    "outputs": [
@@ -505,7 +473,7 @@
        "(torch.Size([1, 8, 4, 32, 8]), torch.Size([1, 8, 32, 32]))"
       ]
      },
-     "execution_count": 64,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -516,7 +484,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 65,
+   "execution_count": null,
    "id": "fa5535e7",
    "metadata": {},
    "outputs": [],
@@ -528,7 +496,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 66,
+   "execution_count": null,
    "id": "7a0dd45c",
    "metadata": {},
    "outputs": [],
@@ -538,7 +506,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 67,
+   "execution_count": null,
    "id": "5787543f",
    "metadata": {},
    "outputs": [],
@@ -551,11 +519,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 68,
+   "execution_count": null,
    "id": "6b92b629",
-   "metadata": {
-    "scrolled": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# %%timeit -n 10\n",
@@ -581,7 +547,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 69,
+   "execution_count": null,
    "id": "24ffda20",
    "metadata": {},
    "outputs": [
@@ -591,7 +557,7 @@
        "torch.Size([1, 64, 32])"
       ]
      },
-     "execution_count": 69,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -602,7 +568,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 70,
+   "execution_count": null,
    "id": "4e627e81",
    "metadata": {},
    "outputs": [
@@ -612,7 +578,7 @@
        "tensor(False, device='cuda:0')"
       ]
      },
-     "execution_count": 70,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -624,7 +590,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 75,
+   "execution_count": null,
    "id": "1a217d48",
    "metadata": {},
    "outputs": [
@@ -646,7 +612,7 @@
        "          -1.8650e-12, -7.8139e-07]]], device='cuda:0')"
       ]
      },
-     "execution_count": 75,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -657,7 +623,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 76,
+   "execution_count": null,
    "id": "62090b28",
    "metadata": {},
    "outputs": [],
@@ -678,7 +644,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 77,
+   "execution_count": null,
    "id": "24084535",
    "metadata": {},
    "outputs": [],
@@ -705,7 +671,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 78,
+   "execution_count": null,
    "id": "f1d10b1d",
    "metadata": {},
    "outputs": [
@@ -727,7 +693,7 @@
        "          -1.9391e-07,  5.5802e-06]]], device='cuda:0')"
       ]
      },
-     "execution_count": 78,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -738,7 +704,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 80,
+   "execution_count": null,
    "id": "b4d3190b",
    "metadata": {},
    "outputs": [
@@ -777,21 +743,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "python3",
    "language": "python",
    "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.10.15"
   }
  },
  "nbformat": 4,

--- a/tests/answerdotai/test_palu.ipynb
+++ b/tests/answerdotai/test_palu.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "02c91ee7",
    "metadata": {},
    "outputs": [],
@@ -13,7 +13,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "31238c7a",
    "metadata": {},
    "outputs": [
@@ -21,9 +21,9 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/home/k/miniconda3/envs/vllm_dev/lib/python3.10/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
+      "/home/k/miniconda3/envs/llm_quant/lib/python3.10/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
       "  from .autonotebook import tqdm as notebook_tqdm\n",
-      "2024-10-17 16:15:34,303\tINFO util.py:154 -- Missing packages: ['ipywidgets']. Run `pip install -U ipywidgets`, then restart the notebook server for rich notebook output.\n"
+      "2024-10-18 14:33:59,953\tINFO util.py:154 -- Missing packages: ['ipywidgets']. Run `pip install -U ipywidgets`, then restart the notebook server for rich notebook output.\n"
      ]
     }
    ],
@@ -33,10 +33,27 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "d1fcbd8d",
+   "metadata": {
+    "heading_collapsed": true
+   },
+   "source": [
+    "### test random\n",
+    "\n",
+    "Test palu kernel random inputs.\n",
+    "\n",
+    "- Output should have some random values.\n",
+    "- **FIXME:** Write now output is all zeros, meaning that it is not updated or there is an error in kernel?"
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "f2898590",
-   "metadata": {},
+   "metadata": {
+    "hidden": true
+   },
    "outputs": [],
    "source": [
     "FLOAT32_BYTES = torch.finfo(torch.float).bits // 8\n",
@@ -70,9 +87,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "15e5f899",
-   "metadata": {},
+   "metadata": {
+    "hidden": true
+   },
    "outputs": [],
    "source": [
     "num_heads = (16, 8)\n",
@@ -84,9 +103,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
+   "id": "80300fa8",
+   "metadata": {
+    "hidden": true
+   },
+   "outputs": [],
+   "source": [
+    "palu_head_size = head_size // 8"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
    "id": "13482506",
-   "metadata": {},
+   "metadata": {
+    "hidden": true
+   },
    "outputs": [],
    "source": [
     "# seed_everything(seed)\n",
@@ -123,7 +156,7 @@
     "\n",
     "# Create the KV caches.\n",
     "key_caches, value_caches = create_kv_caches_with_random(NUM_BLOCKS, block_size, 1,\n",
-    "                                                        num_kv_heads, head_size,\n",
+    "                                                        num_kv_heads, palu_head_size,\n",
     "                                                        kv_cache_dtype, dtype, seed,\n",
     "                                                        device)\n",
     "key_cache, value_cache = key_caches[0], value_caches[0]\n",
@@ -134,17 +167,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "id": "a5d7a077",
-   "metadata": {},
+   "metadata": {
+    "hidden": true
+   },
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "(torch.Size([4321, 8, 16, 32, 8]), torch.Size([4321, 8, 128, 32]))"
+       "(torch.Size([4321, 8, 2, 32, 8]), torch.Size([4321, 8, 16, 32]))"
       ]
      },
-     "execution_count": null,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -155,9 +190,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "id": "0444d0b9",
-   "metadata": {},
+   "metadata": {
+    "hidden": true
+   },
    "outputs": [],
    "source": [
     "# [num_kv_heads, palu_head_size, head_size]\n",
@@ -166,79 +203,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "id": "ca5f41e8",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "tensor([[[1., 1., 1.,  ..., 1., 1., 1.],\n",
-       "         [1., 1., 1.,  ..., 1., 1., 1.],\n",
-       "         [1., 1., 1.,  ..., 1., 1., 1.],\n",
-       "         ...,\n",
-       "         [1., 1., 1.,  ..., 1., 1., 1.],\n",
-       "         [1., 1., 1.,  ..., 1., 1., 1.],\n",
-       "         [1., 1., 1.,  ..., 1., 1., 1.]],\n",
-       "\n",
-       "        [[1., 1., 1.,  ..., 1., 1., 1.],\n",
-       "         [1., 1., 1.,  ..., 1., 1., 1.],\n",
-       "         [1., 1., 1.,  ..., 1., 1., 1.],\n",
-       "         ...,\n",
-       "         [1., 1., 1.,  ..., 1., 1., 1.],\n",
-       "         [1., 1., 1.,  ..., 1., 1., 1.],\n",
-       "         [1., 1., 1.,  ..., 1., 1., 1.]],\n",
-       "\n",
-       "        [[1., 1., 1.,  ..., 1., 1., 1.],\n",
-       "         [1., 1., 1.,  ..., 1., 1., 1.],\n",
-       "         [1., 1., 1.,  ..., 1., 1., 1.],\n",
-       "         ...,\n",
-       "         [1., 1., 1.,  ..., 1., 1., 1.],\n",
-       "         [1., 1., 1.,  ..., 1., 1., 1.],\n",
-       "         [1., 1., 1.,  ..., 1., 1., 1.]],\n",
-       "\n",
-       "        ...,\n",
-       "\n",
-       "        [[1., 1., 1.,  ..., 1., 1., 1.],\n",
-       "         [1., 1., 1.,  ..., 1., 1., 1.],\n",
-       "         [1., 1., 1.,  ..., 1., 1., 1.],\n",
-       "         ...,\n",
-       "         [1., 1., 1.,  ..., 1., 1., 1.],\n",
-       "         [1., 1., 1.,  ..., 1., 1., 1.],\n",
-       "         [1., 1., 1.,  ..., 1., 1., 1.]],\n",
-       "\n",
-       "        [[1., 1., 1.,  ..., 1., 1., 1.],\n",
-       "         [1., 1., 1.,  ..., 1., 1., 1.],\n",
-       "         [1., 1., 1.,  ..., 1., 1., 1.],\n",
-       "         ...,\n",
-       "         [1., 1., 1.,  ..., 1., 1., 1.],\n",
-       "         [1., 1., 1.,  ..., 1., 1., 1.],\n",
-       "         [1., 1., 1.,  ..., 1., 1., 1.]],\n",
-       "\n",
-       "        [[1., 1., 1.,  ..., 1., 1., 1.],\n",
-       "         [1., 1., 1.,  ..., 1., 1., 1.],\n",
-       "         [1., 1., 1.,  ..., 1., 1., 1.],\n",
-       "         ...,\n",
-       "         [1., 1., 1.,  ..., 1., 1., 1.],\n",
-       "         [1., 1., 1.,  ..., 1., 1., 1.],\n",
-       "         [1., 1., 1.,  ..., 1., 1., 1.]]], device='cuda:0',\n",
-       "       dtype=torch.float16)"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "metadata": {
+    "hidden": true,
+    "scrolled": true
+   },
+   "outputs": [],
    "source": [
-    "palu_k_up_proj"
+    "assert palu_k_up_proj.is_contiguous()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "id": "bf386204",
-   "metadata": {},
+   "metadata": {
+    "hidden": true
+   },
    "outputs": [],
    "source": [
     "alibi_slopes = None"
@@ -246,98 +228,92 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "7dd8b6af",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "output = torch.empty_like(query)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "c22c3bb4",
-   "metadata": {},
+   "execution_count": 16,
+   "id": "70546996",
+   "metadata": {
+    "hidden": true,
+    "scrolled": true
+   },
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "tensor([[[ 1.5318e-05,  1.5318e-05,  1.5318e-05,  ...,  1.5318e-05,\n",
-       "           1.5318e-05,  1.5318e-05],\n",
-       "         [ 1.5318e-05,  1.5318e-05,  1.5318e-05,  ...,  1.5318e-05,\n",
-       "           1.5318e-05,  1.5318e-05],\n",
-       "         [ 1.5318e-05,  1.5318e-05,  1.5318e-05,  ...,  1.5318e-05,\n",
-       "           1.5318e-05,  1.5318e-05],\n",
+       "tensor([[[1.0000e+00, 1.0000e+00, 1.0000e+00,  ..., 1.0000e+00,\n",
+       "          1.0000e+00, 1.0000e+00],\n",
+       "         [1.0000e+00, 1.0000e+00, 1.0000e+00,  ..., 1.0000e+00,\n",
+       "          1.0000e+00, 1.0000e+00],\n",
+       "         [1.0000e+00, 1.0000e+00, 1.0000e+00,  ..., 1.0000e+00,\n",
+       "          1.0000e+00, 1.0000e+00],\n",
        "         ...,\n",
-       "         [ 1.5318e-05,  1.5318e-05,  1.5318e-05,  ...,  1.5318e-05,\n",
-       "           1.5318e-05,  1.5318e-05],\n",
-       "         [ 1.5318e-05,  1.5318e-05,  1.5318e-05,  ...,  1.5318e-05,\n",
-       "           1.5318e-05,  1.5318e-05],\n",
-       "         [ 1.5318e-05,  1.5318e-05,  1.5318e-05,  ...,  1.5318e-05,\n",
-       "           1.5318e-05,  1.5318e-05]],\n",
+       "         [1.0000e+00, 1.0000e+00, 1.0000e+00,  ..., 1.0000e+00,\n",
+       "          1.0000e+00, 1.0000e+00],\n",
+       "         [1.0000e+00, 1.0000e+00, 1.0000e+00,  ..., 1.0000e+00,\n",
+       "          1.0000e+00, 1.0000e+00],\n",
+       "         [1.0000e+00, 1.0000e+00, 1.0000e+00,  ..., 1.0000e+00,\n",
+       "          1.0000e+00, 1.0000e+00]],\n",
        "\n",
-       "        [[ 1.5318e-05,  1.5318e-05,  1.5318e-05,  ...,  1.5318e-05,\n",
-       "           1.5318e-05,  1.5318e-05],\n",
-       "         [ 1.5318e-05,  1.5318e-05,  1.5318e-05,  ...,  1.5318e-05,\n",
-       "           1.5318e-05,  1.5318e-05],\n",
-       "         [ 1.5318e-05,  1.5318e-05,  1.5318e-05,  ...,  1.5318e-05,\n",
-       "           1.5318e-05,  1.5318e-05],\n",
+       "        [[1.0000e+00, 1.0000e+00, 1.0000e+00,  ..., 1.0000e+00,\n",
+       "          1.0000e+00, 1.0000e+00],\n",
+       "         [1.0000e+00, 1.0000e+00, 1.0000e+00,  ..., 1.0000e+00,\n",
+       "          1.0000e+00, 1.0000e+00],\n",
+       "         [1.0000e+00, 1.0000e+00, 1.0000e+00,  ..., 1.0000e+00,\n",
+       "          1.0000e+00, 1.0000e+00],\n",
        "         ...,\n",
-       "         [ 1.5318e-05,  1.5318e-05,  1.5318e-05,  ...,  1.5318e-05,\n",
-       "           1.5318e-05,  1.5318e-05],\n",
-       "         [ 1.5318e-05,  1.5318e-05,  1.5318e-05,  ...,  1.5318e-05,\n",
-       "           1.5318e-05,  1.5318e-05],\n",
-       "         [ 1.5318e-05,  1.5318e-05,  1.5318e-05,  ...,  1.5318e-05,\n",
-       "           1.5318e-05,  1.5318e-05]],\n",
+       "         [1.8750e+00, 1.8750e+00, 1.8750e+00,  ..., 1.0510e-43,\n",
+       "          1.2191e-43, 1.2472e-43],\n",
+       "         [1.2752e-43, 1.4574e-43, 1.0000e+00,  ..., 1.0000e+00,\n",
+       "          1.0000e+00, 1.0000e+00],\n",
+       "         [1.0000e+00, 1.0000e+00, 1.0000e+00,  ..., 1.0000e+00,\n",
+       "          1.0000e+00, 1.0000e+00]],\n",
        "\n",
-       "        [[ 2.0000e+00, -1.3994e+00,  7.8125e-03,  ...,  1.2607e+00,\n",
-       "          -0.0000e+00, -1.0752e+00],\n",
-       "         [ 2.0000e+00,  1.1787e+00,  2.0000e+00,  ...,  1.2607e+00,\n",
-       "          -2.0000e+00,  1.3643e+00],\n",
-       "         [-5.1200e+02,  8.3838e-01,  0.0000e+00,  ...,  1.3936e+00,\n",
-       "           2.0000e+00,  1.3086e+00],\n",
+       "        [[0.0000e+00, 1.8750e+00, 0.0000e+00,  ..., 1.8750e+00,\n",
+       "          0.0000e+00, 1.8750e+00],\n",
+       "         [0.0000e+00, 1.8750e+00, 0.0000e+00,  ..., 1.8750e+00,\n",
+       "          0.0000e+00, 1.8750e+00],\n",
+       "         [0.0000e+00, 1.8750e+00, 0.0000e+00,  ..., 1.8750e+00,\n",
+       "          0.0000e+00, 1.8750e+00],\n",
        "         ...,\n",
-       "         [-5.1200e+02,  1.1523e+00,  7.8125e-03,  ..., -1.3926e+00,\n",
-       "           5.1200e+02,  1.2539e+00],\n",
-       "         [ 2.0000e+00, -1.1885e+00,  5.1200e+02,  ..., -9.4141e-01,\n",
-       "          -5.1200e+02,  1.4014e+00],\n",
-       "         [-7.8125e-03, -1.1650e+00, -7.8125e-03,  ...,  1.3857e+00,\n",
-       "          -7.8125e-03, -1.4033e+00]],\n",
+       "         [0.0000e+00, 1.8750e+00, 0.0000e+00,  ..., 1.8750e+00,\n",
+       "          0.0000e+00, 1.8750e+00],\n",
+       "         [0.0000e+00, 1.8750e+00, 0.0000e+00,  ..., 0.0000e+00,\n",
+       "          7.7071e-44, 0.0000e+00],\n",
+       "         [7.8473e-44, 0.0000e+00, 7.9874e-44,  ..., 0.0000e+00,\n",
+       "          8.8282e-44, 0.0000e+00]],\n",
        "\n",
-       "        [[ 5.1200e+02, -1.1143e+00,  5.1200e+02,  ..., -1.2432e+00,\n",
-       "           0.0000e+00,  1.3857e+00],\n",
-       "         [-0.0000e+00,  1.3203e+00,  7.8125e-03,  ...,  1.2158e+00,\n",
-       "          -2.0000e+00, -1.4111e+00],\n",
-       "         [ 7.8125e-03, -1.3076e+00,  7.8125e-03,  ...,  1.2539e+00,\n",
-       "           2.0000e+00,  1.3779e+00],\n",
+       "        [[0.0000e+00, 1.9998e+00, 9.1084e-44,  ..., 0.0000e+00,\n",
+       "          9.9492e-44, 0.0000e+00],\n",
+       "         [1.0229e-43, 0.0000e+00, 1.0510e-43,  ..., 0.0000e+00,\n",
+       "          1.2191e-43, 0.0000e+00],\n",
+       "         [1.2472e-43, 0.0000e+00, 1.2752e-43,  ..., 0.0000e+00,\n",
+       "          1.4574e-43, 0.0000e+00],\n",
        "         ...,\n",
-       "         [ 2.0000e+00,  1.3320e+00,  0.0000e+00,  ...,  1.0322e+00,\n",
-       "           5.1200e+02,  1.3105e+00],\n",
-       "         [ 0.0000e+00,  1.4160e+00, -0.0000e+00,  ..., -1.0869e+00,\n",
-       "          -7.8125e-03, -1.1895e+00],\n",
-       "         [ 5.1200e+02,  1.1475e+00, -0.0000e+00,  ...,  1.3965e+00,\n",
-       "          -7.8125e-03,  1.2988e+00]]], device='cuda:0', dtype=torch.float16)"
+       "         [1.0000e+00, 1.0000e+00, 1.0000e+00,  ..., 1.0000e+00,\n",
+       "          1.0000e+00, 1.0000e+00],\n",
+       "         [1.0000e+00, 1.0000e+00, 1.0000e+00,  ..., 1.0000e+00,\n",
+       "          1.0000e+00, 1.0000e+00],\n",
+       "         [1.0000e+00, 1.0000e+00, 1.0000e+00,  ..., 1.0000e+00,\n",
+       "          1.0000e+00, 1.0000e+00]]], device='cuda:0')"
       ]
      },
-     "execution_count": null,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "output"
+    "output = torch.empty(num_seqs, num_query_heads, palu_head_size); output"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "6b92b629",
-   "metadata": {},
+   "execution_count": 17,
+   "id": "8487b091",
+   "metadata": {
+    "hidden": true
+   },
    "outputs": [],
    "source": [
     "# %%timeit -n 10\n",
-    "output = torch.empty_like(query)\n",
     "ops.paged_attention_mlrd_palu_v1(\n",
     "    output,\n",
     "    query,\n",
@@ -359,48 +335,74 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "a26f6d4c",
-   "metadata": {},
+   "execution_count": 18,
+   "id": "4055fcc8",
+   "metadata": {
+    "hidden": true,
+    "scrolled": true
+   },
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "tensor([[[0., 0., 0.,  ..., 0., 0., 0.],\n",
-       "         [0., 0., 0.,  ..., 0., 0., 0.],\n",
-       "         [0., 0., 0.,  ..., 0., 0., 0.],\n",
+       "tensor([[[0.0000e+00, 0.0000e+00, 0.0000e+00,  ..., 0.0000e+00,\n",
+       "          0.0000e+00, 0.0000e+00],\n",
+       "         [0.0000e+00, 0.0000e+00, 0.0000e+00,  ..., 0.0000e+00,\n",
+       "          0.0000e+00, 0.0000e+00],\n",
+       "         [0.0000e+00, 0.0000e+00, 0.0000e+00,  ..., 0.0000e+00,\n",
+       "          0.0000e+00, 0.0000e+00],\n",
        "         ...,\n",
-       "         [0., 0., 0.,  ..., 0., 0., 0.],\n",
-       "         [0., 0., 0.,  ..., 0., 0., 0.],\n",
-       "         [0., 0., 0.,  ..., 0., 0., 0.]],\n",
+       "         [0.0000e+00, 0.0000e+00, 0.0000e+00,  ..., 0.0000e+00,\n",
+       "          0.0000e+00, 0.0000e+00],\n",
+       "         [0.0000e+00, 0.0000e+00, 0.0000e+00,  ..., 0.0000e+00,\n",
+       "          0.0000e+00, 0.0000e+00],\n",
+       "         [0.0000e+00, 0.0000e+00, 0.0000e+00,  ..., 0.0000e+00,\n",
+       "          0.0000e+00, 0.0000e+00]],\n",
        "\n",
-       "        [[0., 0., 0.,  ..., 0., 0., 0.],\n",
-       "         [0., 0., 0.,  ..., 0., 0., 0.],\n",
-       "         [0., 0., 0.,  ..., 0., 0., 0.],\n",
+       "        [[0.0000e+00, 0.0000e+00, 0.0000e+00,  ..., 0.0000e+00,\n",
+       "          0.0000e+00, 0.0000e+00],\n",
+       "         [0.0000e+00, 0.0000e+00, 0.0000e+00,  ..., 0.0000e+00,\n",
+       "          0.0000e+00, 0.0000e+00],\n",
+       "         [0.0000e+00, 0.0000e+00, 0.0000e+00,  ..., 0.0000e+00,\n",
+       "          0.0000e+00, 0.0000e+00],\n",
        "         ...,\n",
-       "         [0., 0., 0.,  ..., 0., 0., 0.],\n",
-       "         [0., 0., 0.,  ..., 0., 0., 0.],\n",
-       "         [0., 0., 0.,  ..., 0., 0., 0.]],\n",
+       "         [0.0000e+00, 0.0000e+00, 0.0000e+00,  ..., 0.0000e+00,\n",
+       "          0.0000e+00, 0.0000e+00],\n",
+       "         [0.0000e+00, 0.0000e+00, 0.0000e+00,  ..., 0.0000e+00,\n",
+       "          0.0000e+00, 0.0000e+00],\n",
+       "         [0.0000e+00, 0.0000e+00, 0.0000e+00,  ..., 0.0000e+00,\n",
+       "          0.0000e+00, 0.0000e+00]],\n",
        "\n",
-       "        [[0., 0., 0.,  ..., 0., 0., 0.],\n",
-       "         [0., 0., 0.,  ..., 0., 0., 0.],\n",
-       "         [0., 0., 0.,  ..., 0., 0., 0.],\n",
+       "        [[0.0000e+00, 1.8750e+00, 0.0000e+00,  ..., 1.8750e+00,\n",
+       "          0.0000e+00, 1.8750e+00],\n",
+       "         [0.0000e+00, 1.8750e+00, 0.0000e+00,  ..., 1.8750e+00,\n",
+       "          0.0000e+00, 1.8750e+00],\n",
+       "         [0.0000e+00, 1.8750e+00, 0.0000e+00,  ..., 1.8750e+00,\n",
+       "          0.0000e+00, 1.8750e+00],\n",
        "         ...,\n",
-       "         [0., 0., 0.,  ..., 0., 0., 0.],\n",
-       "         [0., 0., 0.,  ..., 0., 0., 0.],\n",
-       "         [0., 0., 0.,  ..., 0., 0., 0.]],\n",
+       "         [0.0000e+00, 1.8750e+00, 0.0000e+00,  ..., 1.8750e+00,\n",
+       "          0.0000e+00, 1.8750e+00],\n",
+       "         [0.0000e+00, 1.8750e+00, 0.0000e+00,  ..., 0.0000e+00,\n",
+       "          7.7071e-44, 0.0000e+00],\n",
+       "         [7.8473e-44, 0.0000e+00, 7.9874e-44,  ..., 0.0000e+00,\n",
+       "          8.8282e-44, 0.0000e+00]],\n",
        "\n",
-       "        [[0., 0., 0.,  ..., 0., 0., 0.],\n",
-       "         [0., 0., 0.,  ..., 0., 0., 0.],\n",
-       "         [0., 0., 0.,  ..., 0., 0., 0.],\n",
+       "        [[0.0000e+00, 1.9998e+00, 9.1084e-44,  ..., 0.0000e+00,\n",
+       "          9.9492e-44, 0.0000e+00],\n",
+       "         [1.0229e-43, 0.0000e+00, 1.0510e-43,  ..., 0.0000e+00,\n",
+       "          1.2191e-43, 0.0000e+00],\n",
+       "         [1.2472e-43, 0.0000e+00, 1.2752e-43,  ..., 0.0000e+00,\n",
+       "          1.4574e-43, 0.0000e+00],\n",
        "         ...,\n",
-       "         [0., 0., 0.,  ..., 0., 0., 0.],\n",
-       "         [0., 0., 0.,  ..., 0., 0., 0.],\n",
-       "         [0., 0., 0.,  ..., 0., 0., 0.]]], device='cuda:0',\n",
-       "       dtype=torch.float16)"
+       "         [1.0000e+00, 1.0000e+00, 1.0000e+00,  ..., 1.0000e+00,\n",
+       "          1.0000e+00, 1.0000e+00],\n",
+       "         [1.0000e+00, 1.0000e+00, 1.0000e+00,  ..., 1.0000e+00,\n",
+       "          1.0000e+00, 1.0000e+00],\n",
+       "         [1.0000e+00, 1.0000e+00, 1.0000e+00,  ..., 1.0000e+00,\n",
+       "          1.0000e+00, 1.0000e+00]]], device='cuda:0')"
       ]
      },
-     "execution_count": null,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -411,39 +413,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "6307870f",
-   "metadata": {},
-   "outputs": [
-    {
-     "ename": "AssertionError",
-     "evalue": "",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mAssertionError\u001b[0m                            Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[51], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m \u001b[38;5;28;01massert\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m torch\u001b[38;5;241m.\u001b[39mall(output \u001b[38;5;241m==\u001b[39m \u001b[38;5;241m0\u001b[39m)\n",
-      "\u001b[0;31mAssertionError\u001b[0m: "
-     ]
-    }
-   ],
-   "source": [
-    "assert not torch.all(output == 0)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "561bb383",
-   "metadata": {},
+   "execution_count": 19,
+   "id": "5db20a61",
+   "metadata": {
+    "hidden": true
+   },
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "torch.Size([4, 16, 128])"
+       "torch.Size([4, 16, 16])"
       ]
      },
-     "execution_count": null,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -454,38 +436,135 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "3c723186",
-   "metadata": {},
+   "execution_count": 20,
+   "id": "7b93bc0b",
+   "metadata": {
+    "hidden": true
+   },
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "torch.Size([4, 16, 128])"
+       "(tensor([[3668],\n",
+       "         [ 185],\n",
+       "         [2209],\n",
+       "         [2856]], device='cuda:0', dtype=torch.int32),\n",
+       " tensor([ 9,  3, 10, 16], device='cuda:0', dtype=torch.int32),\n",
+       " torch.Size([4, 16, 128]))"
       ]
      },
-     "execution_count": null,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "output.shape"
+    "block_tables, seq_lens, query.shape"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "262f7bd9",
+   "metadata": {},
+   "source": [
+    "### test palu paged attn against paged attn"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "24084535",
+   "execution_count": 63,
+   "id": "d91f13aa",
    "metadata": {},
    "outputs": [],
    "source": [
+    "num_seqs = 1\n",
+    "num_blocks = num_seqs\n",
+    "num_heads = 64\n",
+    "\n",
+    "num_kv_heads = 8\n",
+    "head_size = 128\n",
+    "palu_head_size = head_size // 4\n",
+    "x = 8\n",
+    "block_size = 32\n",
+    "\n",
+    "key_cache = torch.randn(num_blocks, num_kv_heads, palu_head_size//x, block_size, x,\n",
+    "                        device=device, dtype=torch.half)\n",
+    "value_cache = torch.randn(num_blocks, num_kv_heads, palu_head_size, block_size,\n",
+    "                          device=device, dtype=torch.half)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 64,
+   "id": "6ffdcfd7",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(torch.Size([1, 8, 4, 32, 8]), torch.Size([1, 8, 32, 32]))"
+      ]
+     },
+     "execution_count": 64,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "key_cache.shape, value_cache.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 65,
+   "id": "fa5535e7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "query = torch.randn(num_seqs, num_heads, head_size, device=device, dtype=torch.half)\n",
+    "block_tables = torch.tensor([[0]], device=device, dtype=torch.int32)\n",
+    "seq_lens = torch.tensor([4], device=device, dtype=torch.int32)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 66,
+   "id": "7a0dd45c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "palu_k_up_proj = torch.randn(num_kv_heads, palu_head_size, head_size, device=device, dtype=torch.half)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 67,
+   "id": "5787543f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "max_seq_len = 4\n",
+    "alibi_slopes = None\n",
+    "kv_cache_dtype = \"auto\"\n",
+    "k_scale = v_scale = 1.0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 68,
+   "id": "6b92b629",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
     "# %%timeit -n 10\n",
-    "output = torch.empty_like(query)\n",
-    "ops.paged_attention_v1(\n",
-    "    output,\n",
+    "test_output = torch.empty(num_seqs, num_heads, palu_head_size)\n",
+    "ops.paged_attention_mlrd_palu_v1(\n",
+    "    test_output,\n",
     "    query,\n",
     "    key_cache,\n",
+    "    palu_k_up_proj,\n",
     "    value_cache,\n",
     "    num_kv_heads,\n",
     "    scale,\n",
@@ -502,63 +581,182 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 69,
+   "id": "24ffda20",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "torch.Size([1, 64, 32])"
+      ]
+     },
+     "execution_count": 69,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "test_output.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 70,
+   "id": "4e627e81",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "tensor(False, device='cuda:0')"
+      ]
+     },
+     "execution_count": 70,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# FIXME: all output is zeros.\n",
+    "torch.all(test_output==0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 75,
+   "id": "1a217d48",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "tensor([[[ 0.0000e+00,  0.0000e+00,  0.0000e+00,  ...,  0.0000e+00,\n",
+       "           0.0000e+00,  0.0000e+00],\n",
+       "         [ 0.0000e+00,  0.0000e+00,  0.0000e+00,  ...,  0.0000e+00,\n",
+       "           0.0000e+00,  0.0000e+00],\n",
+       "         [ 0.0000e+00,  0.0000e+00,  0.0000e+00,  ...,  0.0000e+00,\n",
+       "           0.0000e+00,  0.0000e+00],\n",
+       "         ...,\n",
+       "         [ 1.2741e-02,  1.4058e-09,  7.8694e-07,  ...,  1.0390e-02,\n",
+       "          -1.0547e-03,  1.4940e-13],\n",
+       "         [ 4.3596e-08,  7.5044e-13,  2.0900e-04,  ..., -3.6811e-03,\n",
+       "          -1.1726e-05, -1.2618e-02],\n",
+       "         [-1.2024e-05, -3.2733e-07,  1.4920e-06,  ...,  6.0168e-08,\n",
+       "          -1.8650e-12, -7.8139e-07]]], device='cuda:0')"
+      ]
+     },
+     "execution_count": 75,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "test_output"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 76,
+   "id": "62090b28",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Here we manually up project the \n",
+    "key_cache_tmp = key_cache.permute(0,1,3,4,2).reshape(num_blocks, num_kv_heads, block_size, palu_head_size)\n",
+    "key_cache_tmp = key_cache_tmp.permute(0,2,1,3).reshape(num_blocks*block_size, num_kv_heads, palu_head_size)\n",
+    "\n",
+    "# bmm: num_kv_heads, num_blocks*block_size, palu_head_size @ num_kv_heads, palu_head_size, head_size\n",
+    "# -> num_kv_heads, num_blocks*block_size, head_size\n",
+    "# permute: -> num_blocks*block_size, num_kv_heads, head_size\n",
+    "key_cache_up = torch.bmm(key_cache_tmp.permute(1,0,2), palu_k_up_proj).permute(1,0,2)\n",
+    "key_cache_up = key_cache_up.reshape(num_blocks, block_size, num_kv_heads, head_size//x, x)\n",
+    "\n",
+    "# to original shape: num_blocks, num_kv_heads, head_size//x, block_size, x\n",
+    "key_cache_up = key_cache_up.permute(0,2,3,1,4)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 77,
+   "id": "24084535",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %%timeit -n 10\n",
+    "base_output = torch.empty(num_seqs, num_heads, palu_head_size)\n",
+    "ops.paged_attention_v1(\n",
+    "    base_output,\n",
+    "    query,\n",
+    "    key_cache_up,\n",
+    "    value_cache,\n",
+    "    num_kv_heads,\n",
+    "    scale,\n",
+    "    block_tables,\n",
+    "    seq_lens,\n",
+    "    block_size,\n",
+    "    max_seq_len,\n",
+    "    alibi_slopes,\n",
+    "    kv_cache_dtype,\n",
+    "    k_scale,\n",
+    "    v_scale,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 78,
    "id": "f1d10b1d",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "tensor([[[ 0.0054, -0.0048, -0.0015,  ...,  0.0238, -0.0044, -0.0098],\n",
-       "         [ 0.0054, -0.0048, -0.0015,  ...,  0.0238, -0.0044, -0.0098],\n",
-       "         [-0.0051,  0.0019, -0.0152,  ...,  0.0002, -0.0081,  0.0030],\n",
+       "tensor([[[-1.4245e-03, -3.1543e-03, -1.5170e+00,  ...,  3.1979e-01,\n",
+       "          -4.6233e-10,  9.9317e-04],\n",
+       "         [-4.6809e-02, -3.9276e-05,  1.2437e-01,  ..., -3.6342e-03,\n",
+       "           1.2656e-04, -2.8240e+00],\n",
+       "         [ 9.7393e-05, -3.8031e-06, -4.9628e-07,  ..., -2.2337e+01,\n",
+       "           5.0419e-03, -5.3989e-02],\n",
        "         ...,\n",
-       "         [ 0.0134,  0.0103,  0.0134,  ..., -0.0143, -0.0222,  0.0170],\n",
-       "         [-0.0102, -0.0091,  0.0178,  ..., -0.0154,  0.0082, -0.0058],\n",
-       "         [-0.0103, -0.0092,  0.0179,  ..., -0.0153,  0.0083, -0.0057]],\n",
-       "\n",
-       "        [[ 0.0057,  0.0132,  0.0216,  ...,  0.0173,  0.0064,  0.0083],\n",
-       "         [ 0.0057,  0.0133,  0.0216,  ...,  0.0172,  0.0063,  0.0082],\n",
-       "         [ 0.0148, -0.0280, -0.0303,  ...,  0.0019, -0.0021, -0.0257],\n",
-       "         ...,\n",
-       "         [ 0.0041, -0.0591, -0.0425,  ...,  0.0129,  0.0220, -0.0307],\n",
-       "         [ 0.0197,  0.0287, -0.0024,  ...,  0.0050,  0.0005, -0.0061],\n",
-       "         [ 0.0196,  0.0286, -0.0025,  ...,  0.0048,  0.0006, -0.0061]],\n",
-       "\n",
-       "        [[ 0.0138,  0.0034,  0.0209,  ..., -0.0127, -0.0015,  0.0013],\n",
-       "         [ 0.0137,  0.0034,  0.0209,  ..., -0.0127, -0.0015,  0.0013],\n",
-       "         [-0.0280, -0.0205,  0.0157,  ..., -0.0170, -0.0163,  0.0200],\n",
-       "         ...,\n",
-       "         [-0.0093, -0.0181, -0.0514,  ..., -0.0078,  0.0022, -0.0076],\n",
-       "         [-0.0187,  0.0048,  0.0153,  ..., -0.0241,  0.0068, -0.0044],\n",
-       "         [-0.0187,  0.0047,  0.0152,  ..., -0.0241,  0.0067, -0.0044]],\n",
-       "\n",
-       "        [[-0.0027,  0.0073,  0.0038,  ..., -0.0007,  0.0042, -0.0083],\n",
-       "         [-0.0026,  0.0073,  0.0037,  ..., -0.0008,  0.0042, -0.0083],\n",
-       "         [ 0.0130, -0.0034,  0.0013,  ..., -0.0130,  0.0276, -0.0110],\n",
-       "         ...,\n",
-       "         [ 0.0042, -0.0361,  0.0122,  ..., -0.0104,  0.0105, -0.0144],\n",
-       "         [ 0.0029, -0.0025,  0.0083,  ...,  0.0155, -0.0046, -0.0202],\n",
-       "         [ 0.0029, -0.0025,  0.0083,  ...,  0.0155, -0.0047, -0.0202]]],\n",
-       "       device='cuda:0', dtype=torch.float16)"
+       "         [-1.1876e-05, -7.1635e-03, -4.7026e-05,  ...,  3.5705e-04,\n",
+       "          -3.4625e-05, -7.1183e-01],\n",
+       "         [-5.6910e-05, -1.0234e+01, -4.1433e-04,  ..., -7.5913e-03,\n",
+       "          -5.5052e-06,  1.3659e-09],\n",
+       "         [-1.8383e-06, -5.0255e-03,  9.9629e-03,  ...,  3.5924e-13,\n",
+       "          -1.9391e-07,  5.5802e-06]]], device='cuda:0')"
       ]
      },
-     "execution_count": null,
+     "execution_count": 78,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "output"
+    "base_output"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 80,
    "id": "b4d3190b",
    "metadata": {},
-   "outputs": [],
-   "source": []
+   "outputs": [
+    {
+     "ename": "AssertionError",
+     "evalue": "",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mAssertionError\u001b[0m                            Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[80], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m \u001b[38;5;28;01massert\u001b[39;00m torch\u001b[38;5;241m.\u001b[39mequal(test_output, base_output)\n",
+      "\u001b[0;31mAssertionError\u001b[0m: "
+     ]
+    }
+   ],
+   "source": [
+    "assert torch.equal(test_output, base_output)"
+   ]
   },
   {
    "cell_type": "code",
@@ -579,9 +777,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "python3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.15"
   }
  },
  "nbformat": 4,

--- a/tests/answerdotai/test_palu.ipynb
+++ b/tests/answerdotai/test_palu.ipynb
@@ -1,0 +1,462 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "02c91ee7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import random\n",
+    "import torch"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "afee8aca",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "torch.ops._C.paged_attention_mlrd_palu_v1??"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "11fb1726",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "torch.ops._C.paged_attention_v1??"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "31238c7a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from vllm import _custom_ops as ops\n",
+    "from vllm.utils import get_max_shared_memory_bytes, is_hip, seed_everything, create_kv_caches_with_random"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "f2898590",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "FLOAT32_BYTES = torch.finfo(torch.float).bits // 8\n",
+    "# This will change depending on the compute capability.\n",
+    "# - 512 as a buffer\n",
+    "# MAX_SEQ_LEN = get_max_shared_memory_bytes() // FLOAT32_BYTES - 512\n",
+    "MAX_SEQ_LEN = 16\n",
+    "# There may not be enough gpu memory due to large NUM_BLOCKS.\n",
+    "# Reduce NUM_BLOCKS when it happens.\n",
+    "NUM_BLOCKS = 4321  # Arbitrary values for testing\n",
+    "PARTITION_SIZE = 512\n",
+    "# flshattF and tritonflashattF supported: {torch.float16, torch.bfloat16}\n",
+    "DTYPES = [torch.half, torch.bfloat16, torch.float\n",
+    "          ] if not is_hip() else [torch.half, torch.bfloat16]\n",
+    "NUM_GEN_SEQS = [7]  # Arbitrary values for testing\n",
+    "NUM_PREFILL_SEQS = [3]  # Arbitrary values for testing\n",
+    "NUM_HEADS = [(40, 40), (64, 8)]  # Arbitrary values for testing\n",
+    "\n",
+    "# FlashAttention forward only supports head dimension at most 128\n",
+    "# https://github.com/ROCmSoftwarePlatform/flash-attention/blob/3d2b6f5d037782cc2c906909a46fb7e2e1b48b25/csrc/flash_attn_rocm/flash_api.cpp#L62\n",
+    "HEAD_SIZES = [64, 80, 96, 112, 120, 128, 192, 256]\n",
+    "\n",
+    "BLOCK_SIZES = [16, 32]\n",
+    "USE_ALIBI = [False, True]\n",
+    "KV_CACHE_DTYPE = [\"auto\", \"fp8\"]\n",
+    "SEEDS = [0]\n",
+    "CUDA_DEVICES = [\n",
+    "    f\"cuda:{i}\" for i in range(1 if torch.cuda.device_count() == 1 else 2)\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 59,
+   "id": "15e5f899",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "num_heads = (16, 8)\n",
+    "num_seqs, num_query_heads, head_size = 4, 16, 128\n",
+    "block_size = 32\n",
+    "kv_cache_dtype = \"auto\"\n",
+    "seed = 42"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 60,
+   "id": "13482506",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# seed_everything(seed)\n",
+    "dtype = torch.half\n",
+    "device = \"cuda:0\"\n",
+    "torch.set_default_device(device)\n",
+    "scale = float(1.0 / (head_size**0.5))\n",
+    "num_query_heads, num_kv_heads = num_heads\n",
+    "query = torch.empty(num_seqs, num_query_heads, head_size, dtype=dtype)\n",
+    "query.uniform_(-scale, scale)\n",
+    "\n",
+    "assert num_query_heads % num_kv_heads == 0\n",
+    "num_queries_per_kv = num_query_heads // num_kv_heads\n",
+    "# alibi_slopes = None\n",
+    "# if use_alibi:\n",
+    "#     alibi_slopes = torch.randn(num_query_heads, dtype=torch.float)\n",
+    "\n",
+    "seq_lens = [random.randint(1, MAX_SEQ_LEN) for _ in range(num_seqs)]\n",
+    "seq_lens[-1] = MAX_SEQ_LEN\n",
+    "max_seq_len = max(seq_lens)\n",
+    "seq_lens = torch.tensor(seq_lens, dtype=torch.int)\n",
+    "\n",
+    "# Create the block tables.\n",
+    "max_num_blocks_per_seq = (max_seq_len + block_size - 1) // block_size\n",
+    "block_tables_lst = []\n",
+    "for _ in range(num_seqs):\n",
+    "    block_table = [\n",
+    "        random.randint(0, NUM_BLOCKS - 1)\n",
+    "        for _ in range(max_num_blocks_per_seq)\n",
+    "    ]\n",
+    "    block_tables_lst.append(block_table)\n",
+    "\n",
+    "block_tables = torch.tensor(block_tables_lst, dtype=torch.int)\n",
+    "\n",
+    "# Create the KV caches.\n",
+    "key_caches, value_caches = create_kv_caches_with_random(NUM_BLOCKS, block_size, 1,\n",
+    "                                                        num_kv_heads, head_size,\n",
+    "                                                        kv_cache_dtype, dtype, seed,\n",
+    "                                                        device)\n",
+    "key_cache, value_cache = key_caches[0], value_caches[0]\n",
+    "\n",
+    "# Using default kv_scale\n",
+    "k_scale = v_scale = 1.0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 61,
+   "id": "a5d7a077",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(torch.Size([4321, 8, 16, 32, 8]), torch.Size([4321, 8, 128, 32]))"
+      ]
+     },
+     "execution_count": 61,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "key_cache.shape, value_cache.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 62,
+   "id": "0444d0b9",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "# [num_kv_heads, palu_head_size, head_size]\n",
+    "palu_k_up_proj = torch.randn(5, 16, 128).to(dtype=dtype, device=device)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 63,
+   "id": "b4a3643a",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "torch.Size([5, 16, 128])"
+      ]
+     },
+     "execution_count": 63,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "palu_k_up_proj.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 66,
+   "id": "bf386204",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "alibi_slopes = None"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 78,
+   "id": "6b92b629",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The slowest run took 4.40 times longer than the fastest. This could mean that an intermediate result is being cached.\n",
+      "75.9 μs ± 59.9 μs per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%timeit -n 10\n",
+    "output = torch.empty_like(query)\n",
+    "ops.paged_attention_mlrd_palu_v1(\n",
+    "    output,\n",
+    "    query,\n",
+    "    key_cache,\n",
+    "    palu_k_up_proj,\n",
+    "    value_cache,\n",
+    "    num_kv_heads,\n",
+    "    scale,\n",
+    "    block_tables,\n",
+    "    seq_lens,\n",
+    "    block_size,\n",
+    "    max_seq_len,\n",
+    "    alibi_slopes,\n",
+    "    kv_cache_dtype,\n",
+    "    k_scale,\n",
+    "    v_scale,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 80,
+   "id": "3c723186",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "tensor([[[0., 0., 0.,  ..., 0., 0., 0.],\n",
+       "         [0., 0., 0.,  ..., 0., 0., 0.],\n",
+       "         [0., 0., 0.,  ..., 0., 0., 0.],\n",
+       "         ...,\n",
+       "         [0., 0., 0.,  ..., 0., 0., 0.],\n",
+       "         [0., 0., 0.,  ..., 0., 0., 0.],\n",
+       "         [0., 0., 0.,  ..., 0., 0., 0.]],\n",
+       "\n",
+       "        [[0., 0., 0.,  ..., 0., 0., 0.],\n",
+       "         [0., 0., 0.,  ..., 0., 0., 0.],\n",
+       "         [0., 0., 0.,  ..., 0., 0., 0.],\n",
+       "         ...,\n",
+       "         [0., 0., 0.,  ..., 0., 0., 0.],\n",
+       "         [0., 0., 0.,  ..., 0., 0., 0.],\n",
+       "         [0., 0., 0.,  ..., 0., 0., 0.]],\n",
+       "\n",
+       "        [[0., 0., 0.,  ..., 0., 0., 0.],\n",
+       "         [0., 0., 0.,  ..., 0., 0., 0.],\n",
+       "         [0., 0., 0.,  ..., 0., 0., 0.],\n",
+       "         ...,\n",
+       "         [0., 0., 0.,  ..., 0., 0., 0.],\n",
+       "         [0., 0., 0.,  ..., 0., 0., 0.],\n",
+       "         [0., 0., 0.,  ..., 0., 0., 0.]],\n",
+       "\n",
+       "        [[0., 0., 0.,  ..., 0., 0., 0.],\n",
+       "         [0., 0., 0.,  ..., 0., 0., 0.],\n",
+       "         [0., 0., 0.,  ..., 0., 0., 0.],\n",
+       "         ...,\n",
+       "         [0., 0., 0.,  ..., 0., 0., 0.],\n",
+       "         [0., 0., 0.,  ..., 0., 0., 0.],\n",
+       "         [0., 0., 0.,  ..., 0., 0., 0.]]], device='cuda:0',\n",
+       "       dtype=torch.float16)"
+      ]
+     },
+     "execution_count": 80,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "output"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 79,
+   "id": "24084535",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The slowest run took 4.25 times longer than the fastest. This could mean that an intermediate result is being cached.\n",
+      "74.1 μs ± 56.5 μs per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%timeit -n 10\n",
+    "output = torch.empty_like(query)\n",
+    "ops.paged_attention_v1(\n",
+    "    output,\n",
+    "    query,\n",
+    "    key_cache,\n",
+    "    value_cache,\n",
+    "    num_kv_heads,\n",
+    "    scale,\n",
+    "    block_tables,\n",
+    "    seq_lens,\n",
+    "    block_size,\n",
+    "    max_seq_len,\n",
+    "    alibi_slopes,\n",
+    "    kv_cache_dtype,\n",
+    "    k_scale,\n",
+    "    v_scale,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 73,
+   "id": "f1d10b1d",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "tensor([[[-2.2141e-02,  3.2616e-03, -2.3148e-02,  ..., -3.5370e-02,\n",
+       "          -1.2772e-02, -7.0190e-03],\n",
+       "         [-2.2217e-02,  3.1929e-03, -2.3148e-02,  ..., -3.5461e-02,\n",
+       "          -1.2871e-02, -6.9122e-03],\n",
+       "         [ 3.7415e-02, -3.6392e-03, -4.5898e-02,  ...,  6.8665e-05,\n",
+       "           4.7943e-02, -1.3275e-02],\n",
+       "         ...,\n",
+       "         [ 1.8997e-02, -1.2413e-02, -3.1982e-02,  ..., -5.6793e-02,\n",
+       "           4.4800e-02,  2.9755e-02],\n",
+       "         [ 1.3069e-02, -1.8433e-02,  4.1168e-02,  ...,  1.9741e-04,\n",
+       "           6.8817e-03,  2.7420e-02],\n",
+       "         [ 1.3123e-02, -1.8463e-02,  4.1351e-02,  ...,  1.0681e-04,\n",
+       "           6.9847e-03,  2.7435e-02]],\n",
+       "\n",
+       "        [[-8.0688e-02,  1.5297e-02,  6.9214e-02,  ..., -5.4474e-02,\n",
+       "          -5.7587e-02,  4.4769e-02],\n",
+       "         [-8.0688e-02,  1.5297e-02,  6.9214e-02,  ..., -5.4474e-02,\n",
+       "          -5.7587e-02,  4.4769e-02],\n",
+       "         [ 7.6172e-02,  8.5876e-02, -8.7891e-02,  ...,  2.2278e-02,\n",
+       "          -4.7755e-04,  7.1350e-02],\n",
+       "         ...,\n",
+       "         [ 3.8574e-02,  1.4069e-02,  4.4312e-02,  ..., -7.8003e-02,\n",
+       "           7.9529e-02, -3.9551e-02],\n",
+       "         [-8.5526e-03,  5.0049e-02,  3.8239e-02,  ...,  6.9519e-02,\n",
+       "           6.1462e-02,  4.4006e-02],\n",
+       "         [-8.5526e-03,  5.0049e-02,  3.8239e-02,  ...,  6.9519e-02,\n",
+       "           6.1462e-02,  4.4006e-02]],\n",
+       "\n",
+       "        [[ 1.9531e-02,  1.5625e-02,  3.0518e-05,  ...,  3.4576e-02,\n",
+       "          -2.9221e-03, -2.1000e-03],\n",
+       "         [ 1.9547e-02,  1.5579e-02, -7.6294e-06,  ...,  3.4607e-02,\n",
+       "          -2.9373e-03, -2.0943e-03],\n",
+       "         [-5.4550e-04, -2.2247e-02, -4.1161e-03,  ...,  9.7322e-04,\n",
+       "           2.6512e-03, -5.0774e-03],\n",
+       "         ...,\n",
+       "         [ 2.2339e-02, -5.9624e-03, -9.9716e-03,  ..., -4.1779e-02,\n",
+       "          -1.7136e-02,  1.0071e-02],\n",
+       "         [-1.4259e-02,  2.1454e-02, -8.4305e-03,  ...,  7.5531e-04,\n",
+       "          -4.1870e-02, -1.7761e-02],\n",
+       "         [-1.4275e-02,  2.1454e-02, -8.5068e-03,  ...,  8.1825e-04,\n",
+       "          -4.1779e-02, -1.7822e-02]],\n",
+       "\n",
+       "        [[-6.3705e-03, -7.1487e-03, -1.1375e-02,  ..., -2.1225e-02,\n",
+       "          -9.3460e-03,  5.1270e-03],\n",
+       "         [-6.3972e-03, -7.1793e-03, -1.1421e-02,  ..., -2.1225e-02,\n",
+       "          -9.3155e-03,  5.1346e-03],\n",
+       "         [-8.3923e-03,  1.7670e-02, -3.3913e-03,  ...,  8.9874e-03,\n",
+       "          -8.3847e-03, -8.0948e-03],\n",
+       "         ...,\n",
+       "         [ 1.4900e-02, -1.2207e-02, -8.0948e-03,  ..., -3.3493e-03,\n",
+       "           1.4633e-02, -4.0550e-03],\n",
+       "         [-3.8586e-03, -3.2234e-03, -5.1117e-03,  ...,  1.3397e-02,\n",
+       "           1.6220e-02,  7.9956e-03],\n",
+       "         [-3.8548e-03, -3.2425e-03, -5.1537e-03,  ...,  1.3344e-02,\n",
+       "           1.6327e-02,  8.0338e-03]]], device='cuda:0', dtype=torch.float16)"
+      ]
+     },
+     "execution_count": 73,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "output"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b4d3190b",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "509e53ec",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cd94f095",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.15"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -140,6 +140,69 @@ def paged_attention_v2(
         blocksparse_local_blocks, blocksparse_vert_stride,
         blocksparse_block_size, blocksparse_head_sliding_step)
 
+def paged_attention_mlrd_palu_v1(
+    out: torch.Tensor,
+    query: torch.Tensor,
+    key_cache: torch.Tensor,
+    palu_k_up_proj: torch.Tensor,
+    value_cache: torch.Tensor,
+    num_kv_heads: int,
+    scale: float,
+    block_tables: torch.Tensor,
+    seq_lens: torch.Tensor,
+    block_size: int,
+    max_seq_len: int,
+    alibi_slopes: Optional[torch.Tensor],
+    kv_cache_dtype: str,
+    k_scale: float,
+    v_scale: float,
+    tp_rank: int = 0,
+    blocksparse_local_blocks: int = 0,
+    blocksparse_vert_stride: int = 0,
+    blocksparse_block_size: int = 64,
+    blocksparse_head_sliding_step: int = 0,
+) -> None:
+    torch.ops._C.paged_attention_mlrd_palu_v1(
+        out, query, key_cache, palu_k_up_proj, value_cache, num_kv_heads, scale, block_tables,
+        seq_lens, block_size, max_seq_len, alibi_slopes, kv_cache_dtype,
+        k_scale, v_scale, tp_rank, blocksparse_local_blocks,
+        blocksparse_vert_stride, blocksparse_block_size,
+        blocksparse_head_sliding_step)
+
+
+def paged_attention_mlrd_palu_v2(
+    out: torch.Tensor,
+    exp_sum: torch.Tensor,
+    max_logits: torch.Tensor,
+    tmp_out: torch.Tensor,
+    query: torch.Tensor,
+    key_cache: torch.Tensor,
+    palu_k_up_proj: torch.Tensor,
+    value_cache: torch.Tensor,
+    num_kv_heads: int,
+    scale: float,
+    block_tables: torch.Tensor,
+    seq_lens: torch.Tensor,
+    block_size: int,
+    max_seq_len: int,
+    alibi_slopes: Optional[torch.Tensor],
+    kv_cache_dtype: str,
+    k_scale: float,
+    v_scale: float,
+    tp_rank: int = 0,
+    blocksparse_local_blocks: int = 0,
+    blocksparse_vert_stride: int = 0,
+    blocksparse_block_size: int = 64,
+    blocksparse_head_sliding_step: int = 0,
+) -> None:
+    torch.ops._C.paged_attention_mlrd_palu_v2(
+        out, exp_sum, max_logits, tmp_out, query, key_cache, palu_k_up_proj, value_cache,
+        num_kv_heads, scale, block_tables, seq_lens, block_size, max_seq_len,
+        alibi_slopes, kv_cache_dtype, k_scale, v_scale, tp_rank,
+        blocksparse_local_blocks, blocksparse_vert_stride,
+        blocksparse_block_size, blocksparse_head_sliding_step)
+
+
 
 def paged_attention_rocm(
     out: torch.Tensor,


### PR DESCRIPTION
This PR implements [PALU](https://arxiv.org/pdf/2407.21118) based on the existing XFormers(CLA) attn backend decode and prefill kernels:

<img width="965" alt="Screenshot 2024-10-18 at 6 01 18 PM" src="https://github.com/user-attachments/assets/18ffaa62-051b-459c-a4cd-b8c67daed54f">

Our implementation follows Figure 2 from the paper and implements MLRD (Multi-head low rank decomposition) version from the paper to make implementation easier with the existing paged attention kernels. For example, `Grid: (num_heads, num_seqs, max_num_partitions)` - is the launch parameter for the paged attention kernel meaning that blockDim.x corresponds to a single head so during up projection it will be easier to work with a single head.

Kernel implementations below are responsible only for the (QK^T) @ V portion of the computation, and fused output projection will be handled in the model layer.

**query** - This will have the original head_size without compression as it is computed every time.

**key** - This will be down projected by the fused `Kd_proj` at the model layer before caching. Inside the attention kernel it will be up projected on the fly inside and RoPE will be applied.

**value** - Similar to the key, value will be also down projected by the fused `Vd_proj` at the model layer before caching, but it won't require an up projection inside the kernel since we will be using a fused output projection layer `O_proj` at the model layer.

## 1) PALU Paged Attention Decode CUDA Kernel

- Implemented `csrc/attention/attention_kernels_palu.cu` based on `csrc/attention/attention_kernels.cu`.
- Followed implementation details from the [docs](https://docs.vllm.ai/en/stable/dev/kernel/paged_attention.html#value).
- Only support BLOCK_SIZE=32 (this is paged attn block size not CUDA grid!) to make it equal to WARP_SIZE, to ensure `THREAD_GROUP_SIZE=1` in which case each thread will process all the elements of 1 key token of 1 head at a given time. This way we can up project elements of a single key token of a given head using one thread. This is also to make implementation easier and to avoid dealing with synching across multiple threads during dot product of the up projection.
- Added initial tests in a [notebook](https://github.com/AnswerDotAI/vllm/blob/198dd4e94c4911a1f0857ee6b8037dd280f3e294/tests/answerdotai/test_palu.ipynb) which currently fail.


- [ ] Fix implementation and pass the tests.
- [ ] Add RoPE.

Here we modify


## 2) PALU Paged Attention Prefill Triton Kernel

TODO.

## 3) Remaining changes required at higher level:

Such as handling paged attention KV cache allocation based on `palu_head_size` which can be passed as a config param. Also, other model related code changes as needed.

TODO.
